### PR TITLE
Add maxRayDepth to preferences and wire up query parameter

### DIFF
--- a/src/common/model/SimModel.ts
+++ b/src/common/model/SimModel.ts
@@ -15,6 +15,7 @@ export class RayTracingCommonModel {
       mode: opticsLabQueryParameters.extendedRays ? "extended" : "rays",
       rayDensity: opticsLabQueryParameters.rayDensity,
       showGrid: opticsLabQueryParameters.showGrid,
+      maxRayDepth: opticsLabQueryParameters.maximumLightRayDepth,
     });
   }
 

--- a/src/common/view/SimScreenView.ts
+++ b/src/common/view/SimScreenView.ts
@@ -314,6 +314,24 @@ export class RayTracingCommonView extends ScreenView {
       model.scene.lensRimBlockingProperty.value = v;
     });
 
+    // ── Max ray depth (bidirectional sync for PhET-iO) ──────────────────────
+    model.scene.maxRayDepthProperty.value = _opticsLabPreferences.maxRayDepthProperty.value;
+    let blockRayDepthSync = false;
+    _opticsLabPreferences.maxRayDepthProperty.lazyLink((v) => {
+      if (!blockRayDepthSync) {
+        blockRayDepthSync = true;
+        model.scene.maxRayDepthProperty.value = v;
+        blockRayDepthSync = false;
+      }
+    });
+    model.scene.maxRayDepthProperty.lazyLink((v) => {
+      if (!blockRayDepthSync) {
+        blockRayDepthSync = true;
+        _opticsLabPreferences.maxRayDepthProperty.value = v;
+        blockRayDepthSync = false;
+      }
+    });
+
     const gridVisibleProperty = model.scene.showGridProperty;
     const gridContainer = new Node();
     gridVisibleProperty.linkAttribute(gridContainer, "visible");

--- a/src/i18n/StringManager.ts
+++ b/src/i18n/StringManager.ts
@@ -254,6 +254,8 @@ export class StringManager {
     curvatureDisplayDescriptionStringProperty: ReadOnlyProperty<string>;
     lensRimBlockingStringProperty: ReadOnlyProperty<string>;
     lensRimBlockingDescriptionStringProperty: ReadOnlyProperty<string>;
+    maxRayDepthStringProperty: ReadOnlyProperty<string>;
+    maxRayDepthDescriptionStringProperty: ReadOnlyProperty<string>;
   } {
     const p = this.stringProperties.preferences;
     return {
@@ -274,6 +276,8 @@ export class StringManager {
       curvatureDisplayDescriptionStringProperty: p.curvatureDisplayDescriptionStringProperty,
       lensRimBlockingStringProperty: p.lensRimBlockingStringProperty,
       lensRimBlockingDescriptionStringProperty: p.lensRimBlockingDescriptionStringProperty,
+      maxRayDepthStringProperty: p.maxRayDepthStringProperty,
+      maxRayDepthDescriptionStringProperty: p.maxRayDepthDescriptionStringProperty,
     };
   }
 

--- a/src/i18n/strings_en.json
+++ b/src/i18n/strings_en.json
@@ -24,7 +24,9 @@
     "curvatureDisplay": "Use Curvature (1/R)",
     "curvatureDisplayDescription": "When enabled, sliders show curvature κ = 1/R (m⁻¹) instead of radius of curvature R (m).",
     "lensRimBlocking": "Block Light at Lens Rim",
-    "lensRimBlockingDescription": "When enabled, rays that strike the flat edge of a spherical lens are absorbed rather than refracted, simulating an opaque lens barrel."
+    "lensRimBlockingDescription": "When enabled, rays that strike the flat edge of a spherical lens are absorbed rather than refracted, simulating an opaque lens barrel.",
+    "maxRayDepth": "Max Ray Depth",
+    "maxRayDepthDescription": "Maximum number of times a ray may reflect or refract before tracing stops."
   },
   "ui": {
     "grid": "Grid",

--- a/src/i18n/strings_fr.json
+++ b/src/i18n/strings_fr.json
@@ -24,7 +24,9 @@
     "curvatureDisplay": "Utiliser la courbure (1/R)",
     "curvatureDisplayDescription": "Lorsque activé, les curseurs affichent la courbure κ = 1/R (m⁻¹) au lieu du rayon de courbure R (m).",
     "lensRimBlocking": "Bloquer la lumière au bord de la lentille",
-    "lensRimBlockingDescription": "Lorsque activé, les rayons frappant le bord plat d'une lentille sphérique sont absorbés plutôt que réfractés, simulant un barillet de lentille opaque."
+    "lensRimBlockingDescription": "Lorsque activé, les rayons frappant le bord plat d'une lentille sphérique sont absorbés plutôt que réfractés, simulant un barillet de lentille opaque.",
+    "maxRayDepth": "Profondeur max. des rayons",
+    "maxRayDepthDescription": "Nombre maximal de réflexions ou réfractions d'un rayon avant l'arrêt du tracé."
   },
   "ui": {
     "grid": "Grille",

--- a/src/preferences/OpticsLabPreferencesModel.ts
+++ b/src/preferences/OpticsLabPreferencesModel.ts
@@ -7,7 +7,12 @@
 import { BooleanProperty, NumberProperty, StringUnionProperty } from "scenerystack/axon";
 import { Range } from "scenerystack/dot";
 import type { Tandem } from "scenerystack/tandem";
-import { GRID_SPACING_MAX_M, GRID_SPACING_MIN_M } from "../OpticsLabConstants.js";
+import {
+  GRID_SPACING_MAX_M,
+  GRID_SPACING_MIN_M,
+  MAX_RAY_DEPTH_PROPERTY_MAX,
+  MAX_RAY_DEPTH_PROPERTY_MIN,
+} from "../OpticsLabConstants.js";
 import opticsLab from "../OpticsLabNamespace.js";
 import opticsLabQueryParameters from "./opticsLabQueryParameters.js";
 
@@ -49,6 +54,12 @@ export class OpticsLabPreferencesModel {
    */
   public readonly lensRimBlockingProperty: BooleanProperty;
 
+  /**
+   * Integer cap on ray recursion depth; passed into RayTracer on each simulate().
+   * Same range as `OpticsScene.maxRayDepthProperty`.
+   */
+  public readonly maxRayDepthProperty: NumberProperty;
+
   public constructor(tandem?: Tandem) {
     this.snapToGridProperty = new BooleanProperty(
       opticsLabQueryParameters.snapToGrid,
@@ -79,6 +90,14 @@ export class OpticsLabPreferencesModel {
       opticsLabQueryParameters.lensRimBlocking,
       tandem ? { tandem: tandem.createTandem("lensRimBlockingProperty") } : undefined,
     );
+
+    this.maxRayDepthProperty = new NumberProperty(opticsLabQueryParameters.maximumLightRayDepth, {
+      range: new Range(MAX_RAY_DEPTH_PROPERTY_MIN, MAX_RAY_DEPTH_PROPERTY_MAX),
+      numberType: "Integer",
+      phetioFeatured: true,
+      phetioDocumentation: "Maximum ray recursion depth before tracing stops.",
+      ...(tandem && { tandem: tandem.createTandem("maxRayDepthProperty") }),
+    });
   }
 
   public reset(): void {
@@ -88,6 +107,7 @@ export class OpticsLabPreferencesModel {
     this.partialReflectionEnabledProperty.reset();
     this.useCurvatureDisplayProperty.reset();
     this.lensRimBlockingProperty.reset();
+    this.maxRayDepthProperty.reset();
   }
 }
 

--- a/src/preferences/OpticsLabPreferencesNode.ts
+++ b/src/preferences/OpticsLabPreferencesNode.ts
@@ -15,6 +15,8 @@ import OpticsLabColors from "../OpticsLabColors.js";
 import {
   GRID_SPACING_MAX_M,
   GRID_SPACING_MIN_M,
+  MAX_RAY_DEPTH_PROPERTY_MAX,
+  MAX_RAY_DEPTH_PROPERTY_MIN,
   SLIDER_THUMB_HEIGHT,
   SLIDER_THUMB_WIDTH,
   SLIDER_TRACK_HEIGHT,
@@ -63,6 +65,41 @@ export class OpticsLabPreferencesNode extends VBox {
     );
 
     const gridSpacingDescription = new Text(prefStrings.gridSpacingDescriptionStringProperty, {
+      font: new PhetFont(11),
+      fill: OpticsLabColors.preferencesTextSecondaryProperty,
+      maxWidth: 500,
+    });
+
+    // ── Max Ray Depth ────────────────────────────────────────────────────────
+    const maxRayDepthControl = new NumberControl(
+      prefStrings.maxRayDepthStringProperty,
+      preferencesModel.maxRayDepthProperty,
+      new Range(MAX_RAY_DEPTH_PROPERTY_MIN, MAX_RAY_DEPTH_PROPERTY_MAX),
+      {
+        delta: 1,
+        numberDisplayOptions: {
+          decimalPlaces: 0,
+          textOptions: {
+            fill: OpticsLabColors.preferencesTextProperty,
+          },
+        },
+        titleNodeOptions: {
+          font: new PhetFont(14),
+          fill: OpticsLabColors.preferencesTextProperty,
+          maxWidth: 200,
+        },
+        sliderOptions: {
+          trackSize: new Dimension2(SLIDER_TRACK_WIDTH, SLIDER_TRACK_HEIGHT),
+          thumbSize: new Dimension2(SLIDER_THUMB_WIDTH, SLIDER_THUMB_HEIGHT),
+          trackFillEnabled: OpticsLabColors.preferencesTextProperty,
+        },
+        arrowButtonOptions: { scale: 0.75 },
+        layoutFunction: NumberControl.createLayoutFunction4({ sliderPadding: 5 }),
+        ...(tandem && { tandem: tandem.createTandem("maxRayDepthControl") }),
+      },
+    );
+
+    const maxRayDepthDescription = new Text(prefStrings.maxRayDepthDescriptionStringProperty, {
       font: new PhetFont(11),
       fill: OpticsLabColors.preferencesTextSecondaryProperty,
       maxWidth: 500,
@@ -212,6 +249,8 @@ export class OpticsLabPreferencesNode extends VBox {
         new HStrut(600),
         gridSpacingControl,
         gridSpacingDescription,
+        maxRayDepthControl,
+        maxRayDepthDescription,
         partialReflectionCheckbox,
         lensRimBlockingCheckbox,
         curvatureDisplayCheckbox,


### PR DESCRIPTION
- Pass `maximumLightRayDepth` query parameter into `new OpticsScene(...)` in
  `RayTracingCommonModel` so startup depth matches the URL parameter.
- Add `maxRayDepthProperty` (NumberProperty, integer, 1–500) to
  `OpticsLabPreferencesModel`, initialised from the query parameter and
  instrumented for PhET-iO.
- Add a `NumberControl` for max ray depth to `OpticsLabPreferencesNode`,
  positioned between Grid Size and Partial Reflection.
- Bidirectionally sync `preferencesModel.maxRayDepthProperty` ↔
  `scene.maxRayDepthProperty` in `SimScreenView`, matching the pattern
  used for gridSpacing/snapToGrid.
- Add English and French i18n strings; expose them through
  `StringManager.getPreferences()`.

https://claude.ai/code/session_01JUA8HQWMk2mAgN4GE3jYxn