### PR TITLE
fix: address all 11 adversarial security review findings

### DIFF
--- a/src/OpticsLabConstants.ts
+++ b/src/OpticsLabConstants.ts
@@ -94,6 +94,13 @@ export const RAY_DENSITY_MAX = 5.0;
 export const FAR_DISTANCE = 10000;
 export const MAX_RAY_PAIRS = 500;
 
+/**
+ * Hard cap on the total number of ray segments produced in a single trace.
+ * Prevents a resonating cavity (e.g. two mirrors + beam splitter at high ray
+ * density / depth) from flooding the BFS queue and freezing the main thread.
+ */
+export const MAX_TOTAL_SEGMENTS = 50_000;
+
 // ── 4. Ray canvas rendering ───────────────────────────────────────────────────
 
 /** Forward-ray base colour components (R, G, B). */

--- a/src/common/model/detectors/DetectorElement.ts
+++ b/src/common/model/detectors/DetectorElement.ts
@@ -169,7 +169,11 @@ export class DetectorElement extends BaseSegmentElement {
     return ccw === onArc;
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    _config?: unknown,
+  ): RayInteractionResult {
     const t = this.computeArcT(intersection.point);
     const brightness = ray.brightnessS + ray.brightnessP;
 

--- a/src/common/model/fiber/FiberOpticElement.ts
+++ b/src/common/model/fiber/FiberOpticElement.ts
@@ -30,7 +30,13 @@ import {
 import { ELEMENT_TYPE_FIBER_CORE_GLASS, ELEMENT_TYPE_FIBER_OPTIC } from "../../../OpticsLabStrings.js";
 import { Glass, type GlassPathPoint } from "../glass/Glass.js";
 import type { Point } from "../optics/Geometry.js";
-import type { IntersectionResult, OpticalElement, RayInteractionResult, SimulationRay } from "../optics/OpticsTypes.js";
+import type {
+  IntersectionResult,
+  OpticalElement,
+  RayCallConfig,
+  RayInteractionResult,
+  SimulationRay,
+} from "../optics/OpticsTypes.js";
 
 // ── Default indices ────────────────────────────────────────────────────────────
 
@@ -56,7 +62,11 @@ export class FiberCoreGlass extends Glass {
     this.outerRefIndex = claddingRefIndex;
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    config?: RayCallConfig,
+  ): RayInteractionResult {
     const incidentType = this.getIncidentType(ray);
 
     if (incidentType === 0) {
@@ -80,7 +90,7 @@ export class FiberCoreGlass extends Glass {
       normal = { x: -normal.x, y: -normal.y };
     }
 
-    return this.refractRay(ray, intersection.point, normal, n1);
+    return this.refractRay(ray, intersection.point, normal, n1, config?.partialReflectionEnabled ?? true);
   }
 
   /** Never serialized independently — the parent FiberOpticElement owns serialization. */

--- a/src/common/model/glass/BaseGlass.ts
+++ b/src/common/model/glass/BaseGlass.ts
@@ -17,20 +17,6 @@ import type { ElementCategory, RayInteractionResult, SimulationRay } from "../op
 export abstract class BaseGlass extends BaseElement {
   public readonly category: ElementCategory = ELEMENT_CATEGORY_GLASS;
 
-  /**
-   * Global toggle applied by RayTracer at the start of each simulation pass, driven by
-   * OpticsScene.partialReflectionEnabledProperty. Never set this directly from the view layer.
-   */
-  public static partialReflectionEnabled = true;
-
-  /**
-   * Global toggle applied by RayTracer before each trace pass, driven by
-   * OpticsScene.lensRimBlockingProperty. When true, rays that strike a flat
-   * aperture-rim edge of a SphericalLens are absorbed rather than refracted.
-   * Never set this directly from the view layer.
-   */
-  public static lensRimBlockingEnabled = false;
-
   private _refIndex: number;
   public cauchyB: number;
   public partialReflect: boolean;
@@ -47,7 +33,8 @@ export abstract class BaseGlass extends BaseElement {
 
   protected constructor(refIndex = DEFAULT_REFRACTIVE_INDEX, cauchyB = DEFAULT_CAUCHY_B, partialReflect = true) {
     super();
-    this._refIndex = refIndex;
+    this._refIndex = DEFAULT_REFRACTIVE_INDEX; // temporary; overwritten by setter below
+    this.refIndex = refIndex; // use setter to enforce invariant (no zero)
     this.cauchyB = cauchyB;
     this.partialReflect = partialReflect;
   }
@@ -74,7 +61,13 @@ export abstract class BaseGlass extends BaseElement {
    *   that cos θ_i = −n̂·d̂ > 0).
    * @param n1 - Ratio n_incident / n_transmitted.
    */
-  protected refractRay(ray: SimulationRay, incidentPoint: Point, normal: Point, n1Param: number): RayInteractionResult {
+  protected refractRay(
+    ray: SimulationRay,
+    incidentPoint: Point,
+    normal: Point,
+    n1Param: number,
+    partialReflectionEnabled = true,
+  ): RayInteractionResult {
     let modNeg = false;
     let n1 = n1Param;
     if (n1 < 0) {
@@ -114,7 +107,7 @@ export abstract class BaseGlass extends BaseElement {
 
     let Rs = 0;
     let Rp = 0;
-    if (this.partialReflect && BaseGlass.partialReflectionEnabled) {
+    if (this.partialReflect && partialReflectionEnabled) {
       Rs = ((n1 * cos1 - cos2) / (n1 * cos1 + cos2)) ** 2;
       Rp = ((n1 * cos2 - cos1) / (n1 * cos2 + cos1)) ** 2;
     }

--- a/src/common/model/glass/CircleGlass.ts
+++ b/src/common/model/glass/CircleGlass.ts
@@ -18,7 +18,7 @@ import {
   subtract,
 } from "../optics/Geometry.js";
 import { MIN_RAY_LENGTH_SQ } from "../optics/OpticsConstants.js";
-import type { IntersectionResult, RayInteractionResult, SimulationRay } from "../optics/OpticsTypes.js";
+import type { IntersectionResult, RayCallConfig, RayInteractionResult, SimulationRay } from "../optics/OpticsTypes.js";
 import { BaseGlass } from "./BaseGlass.js";
 
 export class CircleGlass extends BaseGlass {
@@ -62,7 +62,11 @@ export class CircleGlass extends BaseGlass {
     return pointInCircle(ray.origin, circle(this.p1, this.radius)) ? 1 : -1;
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    config?: RayCallConfig,
+  ): RayInteractionResult {
     const incidentType = this.getIncidentType(ray);
     const n1 =
       incidentType === 1
@@ -75,7 +79,7 @@ export class CircleGlass extends BaseGlass {
       normal = point(-normal.x, -normal.y);
     }
 
-    return this.refractRay(ray, intersection.point, normal, n1);
+    return this.refractRay(ray, intersection.point, normal, n1, config?.partialReflectionEnabled ?? true);
   }
 
   public serialize(): Record<string, unknown> {

--- a/src/common/model/glass/Glass.ts
+++ b/src/common/model/glass/Glass.ts
@@ -32,7 +32,7 @@ import {
   subtract,
 } from "../optics/Geometry.js";
 import { MIN_RAY_LENGTH_SQ } from "../optics/OpticsConstants.js";
-import type { IntersectionResult, RayInteractionResult, SimulationRay } from "../optics/OpticsTypes.js";
+import type { IntersectionResult, RayCallConfig, RayInteractionResult, SimulationRay } from "../optics/OpticsTypes.js";
 import { BaseGlass } from "./BaseGlass.js";
 
 export interface GlassPathPoint {
@@ -102,7 +102,7 @@ export class Glass extends BaseGlass {
         if (result && result.distSq < bestDistSq) {
           bestDistSq = result.distSq;
           bestResult = result.hit;
-          if (BaseGlass.lensRimBlockingEnabled && current.isApertureEdge) {
+          if (current.isApertureEdge) {
             bestResult.hitOnApertureEdge = true;
           }
         }
@@ -175,8 +175,12 @@ export class Glass extends BaseGlass {
 
   // ── Ray interaction ──────────────────────────────────────────────────────
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
-    if (BaseGlass.lensRimBlockingEnabled && intersection.hitOnApertureEdge) {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    config?: RayCallConfig,
+  ): RayInteractionResult {
+    if ((config?.lensRimBlockingEnabled ?? false) && intersection.hitOnApertureEdge) {
       return { isAbsorbed: true };
     }
 
@@ -204,7 +208,7 @@ export class Glass extends BaseGlass {
       normal = point(-normal.x, -normal.y);
     }
 
-    return this.refractRay(ray, intersection.point, normal, n1);
+    return this.refractRay(ray, intersection.point, normal, n1, config?.partialReflectionEnabled ?? true);
   }
 
   // ── Inside/outside determination ─────────────────────────────────────────

--- a/src/common/model/glass/HalfPlaneGlass.ts
+++ b/src/common/model/glass/HalfPlaneGlass.ts
@@ -9,7 +9,7 @@
 
 import { ELEMENT_TYPE_PLANE_GLASS } from "../../../OpticsLabStrings.js";
 import { type Point, point, rayLineIntersection, segment, segmentNormal } from "../optics/Geometry.js";
-import type { IntersectionResult, RayInteractionResult, SimulationRay } from "../optics/OpticsTypes.js";
+import type { IntersectionResult, RayCallConfig, RayInteractionResult, SimulationRay } from "../optics/OpticsTypes.js";
 import { BaseGlass } from "./BaseGlass.js";
 
 export class HalfPlaneGlass extends BaseGlass {
@@ -44,7 +44,11 @@ export class HalfPlaneGlass extends BaseGlass {
     return side > 0 ? -1 : 1;
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    config?: RayCallConfig,
+  ): RayInteractionResult {
     const incidentType = this.getIncidentType(ray);
     const n1 =
       incidentType === 1
@@ -57,7 +61,7 @@ export class HalfPlaneGlass extends BaseGlass {
       normal = point(-normal.x, -normal.y);
     }
 
-    return this.refractRay(ray, intersection.point, normal, n1);
+    return this.refractRay(ray, intersection.point, normal, n1, config?.partialReflectionEnabled ?? true);
   }
 
   public serialize(): Record<string, unknown> {

--- a/src/common/model/glass/IdealLens.ts
+++ b/src/common/model/glass/IdealLens.ts
@@ -48,7 +48,11 @@ export class IdealLens extends BaseSegmentElement {
     return { point: hit.point, t: hit.t, element: this, normal };
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    _config?: unknown,
+  ): RayInteractionResult {
     const center = segmentMidpoint(segment(this.p1, this.p2));
     const dx = this.p2.x - this.p1.x;
     const dy = this.p2.y - this.p1.y;

--- a/src/common/model/gratings/ReflectionGrating.ts
+++ b/src/common/model/gratings/ReflectionGrating.ts
@@ -38,7 +38,11 @@ export class ReflectionGrating extends BaseSegmentElement {
     this.dutyCycle = dutyCycle;
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    _config?: unknown,
+  ): RayInteractionResult {
     return gratingRayInteraction(this.linesDensity, this.dutyCycle, ray, intersection, "reflection");
   }
 

--- a/src/common/model/gratings/TransmissionGrating.ts
+++ b/src/common/model/gratings/TransmissionGrating.ts
@@ -38,7 +38,11 @@ export class TransmissionGrating extends BaseSegmentElement {
     this.dutyCycle = dutyCycle;
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    _config?: unknown,
+  ): RayInteractionResult {
     return gratingRayInteraction(this.linesDensity, this.dutyCycle, ray, intersection, "transmission");
   }
 

--- a/src/common/model/gratings/gratingRayInteraction.ts
+++ b/src/common/model/gratings/gratingRayInteraction.ts
@@ -10,6 +10,15 @@ import type { IntersectionResult, RayInteractionResult, SimulationRay } from "..
 
 export type GratingInteractionMode = "transmission" | "reflection";
 
+/** Numerically stable sinc²(x) = (sin(πx)/(πx))². Returns 1 at x=0. */
+function sincSquared(x: number): number {
+  if (Math.abs(x) < 1e-10) {
+    return 1.0;
+  }
+  const pix = Math.PI * x;
+  return (Math.sin(pix) / pix) ** 2;
+}
+
 export function gratingRayInteraction(
   linesDensity: number,
   dutyCycle: number,
@@ -41,7 +50,7 @@ export function gratingRayInteraction(
     );
 
     const arg = m * dutyCycle;
-    const intensity = m === 0 ? 1.0 : (Math.sin(Math.PI * arg) / (Math.PI * arg)) ** 2;
+    const intensity = m === 0 ? 1.0 : sincSquared(arg);
     if (intensity < 0.001) {
       continue;
     }

--- a/src/common/model/mirrors/AperturedParabolicMirror.ts
+++ b/src/common/model/mirrors/AperturedParabolicMirror.ts
@@ -144,7 +144,11 @@ export class AperturedParabolicMirror extends BaseElement {
     return { point: bestHit.point, t: bestT, element: this, normal: facingRay };
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    _config?: unknown,
+  ): RayInteractionResult {
     const n = intersection.normal;
     const d = ray.direction;
     const dn = dot(d, n);

--- a/src/common/model/mirrors/ArcMirror.ts
+++ b/src/common/model/mirrors/ArcMirror.ts
@@ -129,7 +129,11 @@ export class ArcMirror extends BaseElement {
     return { point: best.point, t: best.t, element: this, normal: facingRay };
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    _config?: unknown,
+  ): RayInteractionResult {
     const n = intersection.normal;
     const d = ray.direction;
     const dn = dot(d, n);

--- a/src/common/model/mirrors/BeamSplitterElement.ts
+++ b/src/common/model/mirrors/BeamSplitterElement.ts
@@ -29,7 +29,11 @@ export class BeamSplitterElement extends BaseSegmentElement {
     this.transRatio = transRatio;
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    _config?: unknown,
+  ): RayInteractionResult {
     const n = intersection.normal;
     const d = ray.direction;
     const dn = dot(d, n);

--- a/src/common/model/mirrors/IdealCurvedMirror.ts
+++ b/src/common/model/mirrors/IdealCurvedMirror.ts
@@ -37,7 +37,11 @@ export class IdealCurvedMirror extends BaseSegmentElement {
     this.focalLength = focalLength;
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    _config?: unknown,
+  ): RayInteractionResult {
     const ip = intersection.point;
     const center = segmentMidpoint(segment(this.p1, this.p2));
 

--- a/src/common/model/mirrors/ParabolicMirror.ts
+++ b/src/common/model/mirrors/ParabolicMirror.ts
@@ -114,7 +114,11 @@ export class ParabolicMirror extends BaseElement {
     return { point: bestHit.point, t: bestT, element: this, normal: facingRay };
   }
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    _config?: unknown,
+  ): RayInteractionResult {
     const n = intersection.normal;
     const d = ray.direction;
     const dn = dot(d, n);

--- a/src/common/model/mirrors/SegmentMirror.ts
+++ b/src/common/model/mirrors/SegmentMirror.ts
@@ -19,7 +19,11 @@ export class SegmentMirror extends BaseSegmentElement {
   public readonly type = ELEMENT_TYPE_SEGMENT_MIRROR;
   public readonly category: ElementCategory = ELEMENT_CATEGORY_MIRROR;
 
-  public override onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult {
+  public override onRayIncident(
+    ray: SimulationRay,
+    intersection: IntersectionResult,
+    _config?: unknown,
+  ): RayInteractionResult {
     const n = intersection.normal;
     const d = ray.direction;
     const dn = dot(d, n);

--- a/src/common/model/optics/BaseElement.ts
+++ b/src/common/model/optics/BaseElement.ts
@@ -10,6 +10,7 @@ import type {
   ElementCategory,
   IntersectionResult,
   OpticalElement,
+  RayCallConfig,
   RayInteractionResult,
   SimulationRay,
   ViewMode,
@@ -37,7 +38,7 @@ export abstract class BaseElement implements OpticalElement {
     return null;
   }
 
-  onRayIncident(_ray: SimulationRay, _intersection: IntersectionResult): RayInteractionResult {
+  onRayIncident(_ray: SimulationRay, _intersection: IntersectionResult, _config?: RayCallConfig): RayInteractionResult {
     return { isAbsorbed: true };
   }
 

--- a/src/common/model/optics/Geometry.ts
+++ b/src/common/model/optics/Geometry.ts
@@ -92,6 +92,12 @@ export function cross(a: Point, b: Point): number {
   return a.x * b.y - a.y * b.x;
 }
 
+/**
+ * Returns the unit vector in the direction of p.
+ * Returns a zero vector when p is the zero vector — callers that produce ray
+ * directions MUST guard against this case, since a zero direction causes
+ * downstream division by zero in rayCircleIntersections and similar routines.
+ */
 export function normalize(p: Point): Point {
   const len = Math.hypot(p.x, p.y);
   if (len === 0) {
@@ -195,6 +201,10 @@ export function rayCircleIntersections(rayOrigin: Point, rayDir: Point, c: Circl
   const ox = rayOrigin.x - c.center.x;
   const oy = rayOrigin.y - c.center.y;
   const a = rayDir.x * rayDir.x + rayDir.y * rayDir.y;
+  if (a < 1e-20) {
+    // Zero-length direction vector — no intersection possible (avoids 0/0 = NaN).
+    return [];
+  }
   const b = 2 * (ox * rayDir.x + oy * rayDir.y);
   const cc = ox * ox + oy * oy - c.radius * c.radius;
   const disc = b * b - 4 * a * cc;
@@ -261,9 +271,12 @@ export function perpendicularBisector(seg: Segment): Line {
 
 // ── Polygon centroid ─────────────────────────────────────────────────────────
 
-/** Arithmetic centroid (mean of all vertices) of a polygon. */
+/** Arithmetic centroid (mean of all vertices) of a polygon. Returns origin for empty arrays. */
 export function polygonCentroid(path: { x: number; y: number }[]): Point {
   const n = path.length;
+  if (n === 0) {
+    return point(0, 0);
+  }
   let sx = 0;
   let sy = 0;
   for (const p of path) {
@@ -370,6 +383,9 @@ export function circumcenter(p1: Point, p2: Point, p3: Point): { center: Point; 
  * are collinear.
  */
 export function sampleArcPoints(p1: Point, p2: Point, p3: Point, n: number): Point[] {
+  if (n <= 0) {
+    return [p1];
+  }
   const circumcircle = circumcenter(p1, p2, p3);
   if (!circumcircle) {
     // Collinear: return a straight-line interpolation

--- a/src/common/model/optics/OpticsScene.ts
+++ b/src/common/model/optics/OpticsScene.ts
@@ -428,6 +428,41 @@ export class OpticsScene extends PhetioObject {
 
   // ── Serialization ────────────────────────────────────────────────────────
 
+  /**
+   * Clamp all numeric settings to their valid Property ranges so that a
+   * malformed JSON file cannot cause a PhET-iO Range assertion failure.
+   */
+  private static sanitizeSettings(raw: unknown): Partial<SceneSettings> {
+    if (typeof raw !== "object" || raw === null) {
+      return {};
+    }
+    const s = raw as Record<string, unknown>;
+    const out: Partial<SceneSettings> = {};
+
+    if (typeof s["rayDensity"] === "number" && Number.isFinite(s["rayDensity"])) {
+      out.rayDensity = Math.max(RAY_DENSITY_MIN, Math.min(RAY_DENSITY_MAX, s["rayDensity"]));
+    }
+    if (typeof s["maxRayDepth"] === "number" && Number.isFinite(s["maxRayDepth"])) {
+      out.maxRayDepth = Math.max(
+        MAX_RAY_DEPTH_PROPERTY_MIN,
+        Math.min(MAX_RAY_DEPTH_PROPERTY_MAX, Math.round(s["maxRayDepth"])),
+      );
+    }
+    if (typeof s["gridSize"] === "number" && Number.isFinite(s["gridSize"])) {
+      out.gridSize = Math.max(GRID_SPACING_MIN_M, Math.min(GRID_SPACING_MAX_M, s["gridSize"]));
+    }
+    if (typeof s["showGrid"] === "boolean") {
+      out.showGrid = s["showGrid"];
+    }
+    if (typeof s["snapToGrid"] === "boolean") {
+      out.snapToGrid = s["snapToGrid"];
+    }
+    if (VIEW_MODE_VALUES.includes(s["mode"] as (typeof VIEW_MODE_VALUES)[number])) {
+      out.mode = s["mode"] as ViewMode;
+    }
+    return out;
+  }
+
   public toJSON(): string {
     return JSON.stringify(
       {
@@ -439,18 +474,30 @@ export class OpticsScene extends PhetioObject {
     );
   }
 
-  public static fromJSON(json: string): OpticsScene {
-    const data = JSON.parse(json) as {
-      settings?: Partial<SceneSettings>;
-      elements?: Record<string, unknown>[];
-    };
-    const scene = new OpticsScene(Tandem.OPT_OUT, data.settings ?? {});
-    for (const obj of data.elements ?? []) {
-      const element = deserializeElement(obj);
-      if (element !== null) {
-        scene.addElement(element);
+  public static fromJSON(json: string): OpticsScene | null {
+    try {
+      const data = JSON.parse(json) as {
+        settings?: Partial<SceneSettings>;
+        elements?: unknown[];
+      };
+      const scene = new OpticsScene(Tandem.OPT_OUT, OpticsScene.sanitizeSettings(data.settings));
+      const elements = Array.isArray(data.elements) ? data.elements : [];
+      for (const obj of elements) {
+        if (typeof obj !== "object" || obj === null) {
+          continue;
+        }
+        try {
+          const element = deserializeElement(obj as Record<string, unknown>);
+          if (element !== null) {
+            scene.addElement(element, false);
+          }
+        } catch {
+          // Invalid element — skip and continue loading remaining elements.
+        }
       }
+      return scene;
+    } catch {
+      return null;
     }
-    return scene;
   }
 }

--- a/src/common/model/optics/OpticsTypes.ts
+++ b/src/common/model/optics/OpticsTypes.ts
@@ -96,10 +96,20 @@ export interface IEmitter {
   emitRays(rayDensity: number, mode: ViewMode, jitter?: boolean): SimulationRay[];
 }
 
+/**
+ * Per-call configuration forwarded by RayTracer into each element's onRayIncident.
+ * Replaces the former static flags on BaseGlass so that parallel traces never
+ * corrupt each other's preferences.
+ */
+export interface RayCallConfig {
+  partialReflectionEnabled: boolean;
+  lensRimBlockingEnabled: boolean;
+}
+
 /** An element that can be intersected by a ray (mirrors, glass, blockers, …). */
 export interface IIntersectable {
   checkRayIntersection(ray: SimulationRay): IntersectionResult | null;
-  onRayIncident(ray: SimulationRay, intersection: IntersectionResult): RayInteractionResult;
+  onRayIncident(ray: SimulationRay, intersection: IntersectionResult, config?: RayCallConfig): RayInteractionResult;
 }
 
 /** An element that can be serialized for persistence. */

--- a/src/common/model/optics/RayTracer.ts
+++ b/src/common/model/optics/RayTracer.ts
@@ -19,10 +19,10 @@ import {
   DEFAULT_MIN_BRIGHTNESS,
   DEFAULT_RAY_DENSITY,
   FAR_DISTANCE,
+  MAX_TOTAL_SEGMENTS,
   RAY_CONVERGENCE_THRESHOLD,
 } from "../../../OpticsLabConstants.js";
 import { ELEMENT_CATEGORY_LIGHT_SOURCE, VIEW_MODE_RAYS } from "../../../OpticsLabStrings.js";
-import { BaseGlass } from "../glass/BaseGlass.js";
 import {
   add,
   distanceSquared,
@@ -38,6 +38,7 @@ import type {
   IntersectionResult,
   Observer,
   OpticalElement,
+  RayCallConfig,
   SimulationRay,
   SimulationResult,
   ViewMode,
@@ -90,6 +91,12 @@ export interface RayTracerConfig {
   partialReflectionEnabled?: boolean;
   /** Whether flat aperture-rim edges of SphericalLens elements absorb rays instead of refracting them. */
   lensRimBlockingEnabled?: boolean;
+  /**
+   * Hard cap on total ray segments produced per trace. BFS terminates early
+   * when this limit is exceeded, preventing main-thread freezes in resonating
+   * cavities at high ray density / depth. Defaults to MAX_TOTAL_SEGMENTS.
+   */
+  maxTotalSegments?: number;
 }
 
 const DEFAULT_CONFIG: RayTracerConfig = {
@@ -109,6 +116,10 @@ export class RayTracer {
   public constructor(elements: OpticalElement[], config: Partial<RayTracerConfig> = {}) {
     this.elements = elements;
     this.config = { ...DEFAULT_CONFIG, ...config };
+    this.callConfig = {
+      partialReflectionEnabled: this.config.partialReflectionEnabled ?? true,
+      lensRimBlockingEnabled: this.config.lensRimBlockingEnabled ?? false,
+    };
   }
 
   /**
@@ -116,12 +127,6 @@ export class RayTracer {
    * propagate them through the scene.
    */
   public trace(): TraceResult {
-    // Apply the partial-reflection flag to the glass base class before tracing.
-    // This keeps the preference in the model layer rather than requiring the view
-    // to mutate a model static directly.
-    BaseGlass.partialReflectionEnabled = this.config.partialReflectionEnabled ?? true;
-    BaseGlass.lensRimBlockingEnabled = this.config.lensRimBlockingEnabled ?? false;
-
     const allSegments: TracedSegment[] = [];
     const allImages: DetectedImage[] = [];
     let totalTruncation = 0;
@@ -135,8 +140,16 @@ export class RayTracer {
 
     // Process each ray through the scene
     const queue: Array<{ ray: SimulationRay; depth: number }> = initialRays.map((ray) => ({ ray, depth: 0 }));
+    const segmentCap = this.config.maxTotalSegments ?? MAX_TOTAL_SEGMENTS;
 
     while (queue.length > 0) {
+      if (allSegments.length >= segmentCap) {
+        // Truncate remaining queued rays to prevent main-thread freeze.
+        for (const { ray } of queue) {
+          totalTruncation += ray.brightnessS + ray.brightnessP;
+        }
+        break;
+      }
       const entry = queue.shift();
       if (!entry) {
         continue;
@@ -161,6 +174,11 @@ export class RayTracer {
       truncationError: totalTruncation,
     };
   }
+
+  private readonly callConfig: RayCallConfig = {
+    partialReflectionEnabled: true,
+    lensRimBlockingEnabled: false,
+  };
 
   private processRayEntry(
     ray: SimulationRay,
@@ -206,7 +224,7 @@ export class RayTracer {
       this.processObserverRay(ray, intersection, allSegments);
     }
 
-    const result = intersection.element.onRayIncident(ray, intersection);
+    const result = intersection.element.onRayIncident(ray, intersection, this.callConfig);
 
     if (!result.isAbsorbed && result.outgoingRay) {
       result.outgoingRay.sourceId = ray.sourceId;

--- a/src/common/model/optics/elementSerialization.ts
+++ b/src/common/model/optics/elementSerialization.ts
@@ -82,9 +82,33 @@ export const ARCHETYPE_ELEMENT_STATE: Record<string, unknown> = {
 /** Internal key: live model reference when adding an element without round-trip clone. */
 export const LIVE_ELEMENT_STATE_KEY = "__opticsLabLiveElement__";
 
-function asPoint(v: unknown): Point {
+function asPoint(v: unknown, field: string): Point {
+  if (
+    typeof v !== "object" ||
+    v === null ||
+    typeof (v as Record<string, unknown>)["x"] !== "number" ||
+    typeof (v as Record<string, unknown>)["y"] !== "number"
+  ) {
+    throw new Error(`Invalid point at field "${field}": ${JSON.stringify(v)}`);
+  }
   const p = v as { x: number; y: number };
+  if (!(Number.isFinite(p.x) && Number.isFinite(p.y))) {
+    throw new Error(`Non-finite point at field "${field}": ${JSON.stringify(v)}`);
+  }
   return point(p.x, p.y);
+}
+
+function asNumber(v: unknown, field: string, min?: number, max?: number): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) {
+    throw new Error(`Invalid number at field "${field}": ${JSON.stringify(v)}`);
+  }
+  if (min !== undefined && v < min) {
+    throw new Error(`Value at field "${field}" (${v}) is below minimum ${min}`);
+  }
+  if (max !== undefined && v > max) {
+    throw new Error(`Value at field "${field}" (${v}) exceeds maximum ${max}`);
+  }
+  return v;
 }
 
 function assignElementId(element: OpticalElement, rawId: unknown): void {
@@ -93,134 +117,148 @@ function assignElementId(element: OpticalElement, rawId: unknown): void {
   }
 }
 
+/** Minimum allowed refractive index (must be strictly positive and non-zero). */
+const REF_INDEX_MIN = 1e-9;
+
 export function deserializeElement(obj: Record<string, unknown>): OpticalElement | null {
   switch (obj["type"]) {
     case ELEMENT_TYPE_POINT_SOURCE: {
       const el = new PointSourceElement(
-        point(obj["x"] as number, obj["y"] as number),
-        obj["brightness"] as number,
-        obj["wavelength"] as number,
+        point(asNumber(obj["x"], "x"), asNumber(obj["y"], "y")),
+        asNumber(obj["brightness"], "brightness", 0),
+        asNumber(obj["wavelength"], "wavelength", 0),
       );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_BEAM: {
       const el = new BeamSource(
-        asPoint(obj["p1"]),
-        asPoint(obj["p2"]),
-        obj["brightness"] as number,
-        obj["wavelength"] as number,
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["brightness"], "brightness", 0),
+        asNumber(obj["wavelength"], "wavelength", 0),
       );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_DIVERGENT_BEAM: {
       const el = new DivergentBeam(
-        asPoint(obj["p1"]),
-        asPoint(obj["p2"]),
-        obj["brightness"] as number,
-        obj["wavelength"] as number,
-        obj["emisAngle"] as number,
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["brightness"], "brightness", 0),
+        asNumber(obj["wavelength"], "wavelength", 0),
+        asNumber(obj["emisAngle"], "emisAngle", 0),
       );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_SINGLE_RAY: {
       const el = new SingleRaySource(
-        asPoint(obj["p1"]),
-        asPoint(obj["p2"]),
-        obj["brightness"] as number,
-        obj["wavelength"] as number,
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["brightness"], "brightness", 0),
+        asNumber(obj["wavelength"], "wavelength", 0),
       );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_ARC_SOURCE: {
       const el = new ArcLightSource(
-        point(obj["x"] as number, obj["y"] as number),
-        obj["direction"] as number,
-        obj["emissionAngle"] as number,
-        obj["brightness"] as number,
-        obj["wavelength"] as number,
+        point(asNumber(obj["x"], "x"), asNumber(obj["y"], "y")),
+        asNumber(obj["direction"], "direction"),
+        asNumber(obj["emissionAngle"], "emissionAngle", 0),
+        asNumber(obj["brightness"], "brightness", 0),
+        asNumber(obj["wavelength"], "wavelength", 0),
       );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_CONTINUOUS_SPECTRUM_SOURCE: {
       const el = new ContinuousSpectrumSource(
-        asPoint(obj["p1"]),
-        asPoint(obj["p2"]),
-        obj["wavelengthMin"] as number,
-        obj["wavelengthStep"] as number,
-        obj["wavelengthMax"] as number,
-        obj["brightness"] as number,
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["wavelengthMin"], "wavelengthMin", 0),
+        asNumber(obj["wavelengthStep"], "wavelengthStep", 0),
+        asNumber(obj["wavelengthMax"], "wavelengthMax", 0),
+        asNumber(obj["brightness"], "brightness", 0),
       );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_SEGMENT_MIRROR: {
-      const el = new SegmentMirror(asPoint(obj["p1"]), asPoint(obj["p2"]));
+      const el = new SegmentMirror(asPoint(obj["p1"], "p1"), asPoint(obj["p2"], "p2"));
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_ARC_MIRROR: {
-      const el = new ArcMirror(asPoint(obj["p1"]), asPoint(obj["p2"]), asPoint(obj["p3"]));
+      const el = new ArcMirror(asPoint(obj["p1"], "p1"), asPoint(obj["p2"], "p2"), asPoint(obj["p3"], "p3"));
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_PARABOLIC_MIRROR: {
-      const el = new ParabolicMirror(asPoint(obj["p1"]), asPoint(obj["p2"]), asPoint(obj["p3"]));
+      const el = new ParabolicMirror(asPoint(obj["p1"], "p1"), asPoint(obj["p2"], "p2"), asPoint(obj["p3"], "p3"));
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_IDEAL_MIRROR: {
-      const el = new IdealCurvedMirror(asPoint(obj["p1"]), asPoint(obj["p2"]), obj["focalLength"] as number);
+      const el = new IdealCurvedMirror(
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["focalLength"], "focalLength"),
+      );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_BEAM_SPLITTER: {
-      const el = new BeamSplitterElement(asPoint(obj["p1"]), asPoint(obj["p2"]), obj["transRatio"] as number);
+      const el = new BeamSplitterElement(
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["transRatio"], "transRatio", 0, 1),
+      );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_GLASS: {
-      const el = new Glass(obj["path"] as GlassPathPoint[], obj["refIndex"] as number);
+      if (!Array.isArray(obj["path"]) || (obj["path"] as unknown[]).length < 3) {
+        throw new Error(`Glass path must have at least 3 vertices`);
+      }
+      const el = new Glass(obj["path"] as GlassPathPoint[], asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN));
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_EQUILATERAL_PRISM: {
       const el = new EquilateralPrism(
-        point(obj["cx"] as number, obj["cy"] as number),
-        obj["size"] as number,
-        obj["refIndex"] as number,
+        point(asNumber(obj["cx"], "cx"), asNumber(obj["cy"], "cy")),
+        asNumber(obj["size"], "size", 0),
+        asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN),
       );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_RIGHT_ANGLE_PRISM: {
       const el = new RightAnglePrism(
-        point(obj["cx"] as number, obj["cy"] as number),
-        obj["legLength"] as number,
-        obj["refIndex"] as number,
+        point(asNumber(obj["cx"], "cx"), asNumber(obj["cy"], "cy")),
+        asNumber(obj["legLength"], "legLength", 0),
+        asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN),
       );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_PORRO_PRISM: {
       const el = new PorroPrism(
-        point(obj["cx"] as number, obj["cy"] as number),
-        obj["legLength"] as number,
-        obj["refIndex"] as number,
+        point(asNumber(obj["cx"], "cx"), asNumber(obj["cy"], "cy")),
+        asNumber(obj["legLength"], "legLength", 0),
+        asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN),
       );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_SLAB_GLASS: {
       const el = new SlabGlass(
-        point(obj["cx"] as number, obj["cy"] as number),
-        obj["width"] as number,
-        obj["height"] as number,
-        obj["refIndex"] as number,
+        point(asNumber(obj["cx"], "cx"), asNumber(obj["cy"], "cy")),
+        asNumber(obj["width"], "width", 0),
+        asNumber(obj["height"], "height", 0),
+        asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN),
       );
       if (typeof obj["rotation"] === "number" && obj["rotation"] !== 0) {
         el.setRotation(obj["rotation"]);
@@ -230,10 +268,10 @@ export function deserializeElement(obj: Record<string, unknown>): OpticalElement
     }
     case ELEMENT_TYPE_PARALLELOGRAM_PRISM: {
       const el = new ParallelogramPrism(
-        point(obj["cx"] as number, obj["cy"] as number),
-        obj["width"] as number,
-        obj["height"] as number,
-        obj["refIndex"] as number,
+        point(asNumber(obj["cx"], "cx"), asNumber(obj["cy"], "cy")),
+        asNumber(obj["width"], "width", 0),
+        asNumber(obj["height"], "height", 0),
+        asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN),
       );
       if (typeof obj["rotation"] === "number" && obj["rotation"] !== 0) {
         el.setRotation(obj["rotation"]);
@@ -243,10 +281,10 @@ export function deserializeElement(obj: Record<string, unknown>): OpticalElement
     }
     case ELEMENT_TYPE_DOVE_PRISM: {
       const el = new DovePrism(
-        point(obj["cx"] as number, obj["cy"] as number),
-        obj["width"] as number,
-        obj["height"] as number,
-        obj["refIndex"] as number,
+        point(asNumber(obj["cx"], "cx"), asNumber(obj["cy"], "cy")),
+        asNumber(obj["width"], "width", 0),
+        asNumber(obj["height"], "height", 0),
+        asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN),
       );
       if (typeof obj["rotation"] === "number" && obj["rotation"] !== 0) {
         el.setRotation(obj["rotation"]);
@@ -255,84 +293,114 @@ export function deserializeElement(obj: Record<string, unknown>): OpticalElement
       return el;
     }
     case ELEMENT_TYPE_SPHERICAL_LENS: {
+      const r1 = asNumber(obj["r1"], "r1");
+      const r2 = asNumber(obj["r2"], "r2");
+      const d = asNumber(obj["d"], "d", 0);
       const lens = new SphericalLens(
-        asPoint(obj["p1"]),
-        asPoint(obj["p2"]),
-        obj["r1"] as number,
-        obj["r2"] as number,
-        obj["refIndex"] as number,
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        r1,
+        r2,
+        asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN),
       );
-      lens.createLensWithDR1R2(obj["d"] as number, obj["r1"] as number, obj["r2"] as number);
+      lens.createLensWithDR1R2(d, r1, r2);
       assignElementId(lens, obj["id"]);
       return lens;
     }
     case ELEMENT_TYPE_CIRCLE_GLASS: {
-      const el = new CircleGlass(asPoint(obj["p1"]), asPoint(obj["p2"]), obj["refIndex"] as number);
+      const el = new CircleGlass(
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN),
+      );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_PLANE_GLASS: {
-      const el = new HalfPlaneGlass(asPoint(obj["p1"]), asPoint(obj["p2"]), obj["refIndex"] as number);
+      const el = new HalfPlaneGlass(
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN),
+      );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_IDEAL_LENS: {
-      const el = new IdealLens(asPoint(obj["p1"]), asPoint(obj["p2"]), obj["focalLength"] as number);
+      const el = new IdealLens(
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["focalLength"], "focalLength"),
+      );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_APERTURE: {
-      const el = new ApertureElement(asPoint(obj["p1"]), asPoint(obj["p2"]), asPoint(obj["p3"]), asPoint(obj["p4"]));
+      const el = new ApertureElement(
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asPoint(obj["p3"], "p3"),
+        asPoint(obj["p4"], "p4"),
+      );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_LINE_BLOCKER: {
-      const el = new LineBlocker(asPoint(obj["p1"]), asPoint(obj["p2"]));
+      const el = new LineBlocker(asPoint(obj["p1"], "p1"), asPoint(obj["p2"], "p2"));
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_DETECTOR: {
-      const p3 = obj["p3"] !== undefined ? asPoint(obj["p3"]) : undefined;
-      const el = new DetectorElement(asPoint(obj["p1"]), asPoint(obj["p2"]), p3);
+      const p3 = obj["p3"] !== undefined ? asPoint(obj["p3"], "p3") : undefined;
+      const el = new DetectorElement(asPoint(obj["p1"], "p1"), asPoint(obj["p2"], "p2"), p3);
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_REFLECTION_GRATING: {
       const el = new ReflectionGrating(
-        asPoint(obj["p1"]),
-        asPoint(obj["p2"]),
-        obj["linesDensity"] as number,
-        obj["dutyCycle"] as number,
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["linesDensity"], "linesDensity", 0),
+        asNumber(obj["dutyCycle"], "dutyCycle", 1e-9, 1 - 1e-9),
       );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_TRANSMISSION_GRATING: {
       const el = new TransmissionGrating(
-        asPoint(obj["p1"]),
-        asPoint(obj["p2"]),
-        obj["linesDensity"] as number,
-        obj["dutyCycle"] as number,
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["linesDensity"], "linesDensity", 0),
+        asNumber(obj["dutyCycle"], "dutyCycle", 1e-9, 1 - 1e-9),
       );
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_TRACK: {
-      const el = new TrackElement(asPoint(obj["p1"]), asPoint(obj["p2"]));
+      const el = new TrackElement(asPoint(obj["p1"], "p1"), asPoint(obj["p2"], "p2"));
       assignElementId(el, obj["id"]);
       return el;
     }
     case ELEMENT_TYPE_FIBER_OPTIC: {
+      const claddingRefIndex = asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN);
+      const coreRefIndex =
+        obj["coreRefIndex"] !== undefined ? asNumber(obj["coreRefIndex"], "coreRefIndex", REF_INDEX_MIN) : undefined;
+      if (coreRefIndex !== undefined && coreRefIndex <= claddingRefIndex) {
+        throw new Error(
+          `Fiber core refractive index (${coreRefIndex}) must exceed cladding index (${claddingRefIndex}) for total internal reflection guiding`,
+        );
+      }
       const el = new FiberOpticElement(
-        asPoint(obj["p1"]),
-        asPoint(obj["cp1"]),
-        asPoint(obj["cp2"]),
-        asPoint(obj["cp3"]),
-        asPoint(obj["p2"]),
-        obj["outerRadius"] as number,
-        obj["refIndex"] as number,
-        obj["coreRadiusFraction"] as number | undefined,
-        obj["coreRefIndex"] as number | undefined,
+        asPoint(obj["p1"], "p1"),
+        asPoint(obj["cp1"], "cp1"),
+        asPoint(obj["cp2"], "cp2"),
+        asPoint(obj["cp3"], "cp3"),
+        asPoint(obj["p2"], "p2"),
+        asNumber(obj["outerRadius"], "outerRadius", 0),
+        claddingRefIndex,
+        obj["coreRadiusFraction"] !== undefined
+          ? asNumber(obj["coreRadiusFraction"], "coreRadiusFraction", 0, 1)
+          : undefined,
+        coreRefIndex,
       );
       assignElementId(el, obj["id"]);
       return el;


### PR DESCRIPTION
F1 — Remove global mutable statics from BaseGlass. Introduce RayCallConfig
interface and thread partialReflectionEnabled / lensRimBlockingEnabled through
RayTracer.callConfig → onRayIncident(..., config) instead of mutating statics
before each trace. All glass implementations (Glass, CircleGlass, HalfPlaneGlass,
FiberCoreGlass) forward the flag to refractRay(). Non-glass elements accept the
optional param and ignore it.

F2 — Replace unsafe asPoint() cast with a validating version that checks object
shape, numeric types, and finiteness, throwing a descriptive error on bad input.
Add asNumber() helper that validates finite numeric fields with optional min/max
bounds. All call sites updated with field-name diagnostics.

F3 — Wrap OpticsScene.fromJSON in try/catch; return null on parse failure.
Per-element deserialization is also guarded with an inner try/catch so one bad
element cannot abort loading the rest of the scene. Add sanitizeSettings() to
clamp all numeric settings to their Property ranges before construction.

F4 — Guard polygonCentroid against empty array (returns origin instead of NaN).

F5 — Replace raw sinc expression in gratingRayInteraction with sincSquared()
that returns 1.0 at x=0, eliminating the 0/0 NaN cascade from dutyCycle=0.

F6 — Route BaseGlass constructor through the refIndex setter so zero is rejected
at construction time (not only via direct assignment).

F7 — Document normalize's zero-vector behaviour and guard rayCircleIntersections
against a=0 (zero-length direction), returning [] instead of producing NaN/Inf.

F8 — Replace all `as number` casts in deserializeElement with validated asNumber()
calls including appropriate min/max bounds for refIndex, brightness, dutyCycle,
geometry scalars, etc.

F9 — Enforce coreRefIndex > claddingRefIndex in fiber optic deserialization;
throw a descriptive error when the invariant is violated.

F10 — Guard sampleArcPoints against n≤0; return [p1] immediately.

F11 — Add maxTotalSegments cap (default 50 000) to RayTracerConfig. BFS loop
terminates early when the segment count reaches the cap, counting remaining
queued ray brightness as truncation instead of freezing the main thread.

https://claude.ai/code/session_01E18Y4g1MABtP4oLNtKYdnq