### PR TITLE
Add bounding boxes, spatial index, property-edit undo, and fiber bend loss

### DIFF
--- a/src/OpticsLabConstants.ts
+++ b/src/OpticsLabConstants.ts
@@ -579,6 +579,19 @@ export const ARCHETYPE_DEFAULT_WAVELENGTH_NM = 550;
 /** Refractive index of the fiber-optic core (must be > cladding index for TIR guiding). */
 export const FIBER_OPTIC_CORE_REFRACTIVE_INDEX = 1.62;
 
+/**
+ * Bend loss coefficient (dB/m per (1/R) unit).
+ * Controls how strongly curvature attenuates rays. Higher values produce
+ * more aggressive attenuation at tight bends. Set to 0 to disable.
+ */
+export const FIBER_OPTIC_DEFAULT_BEND_LOSS_COEFF = 2.0;
+
+/**
+ * Critical bend radius (m) below which bend loss kicks in.
+ * Above this radius, loss is negligible. Below it, loss scales with 1/R.
+ */
+export const FIBER_OPTIC_CRITICAL_BEND_RADIUS = 0.5;
+
 // ── 24. Font strings ──────────────────────────────────────────────────────────
 //
 // All UI text in the simulation uses "sans-serif" at one of these sizes.

--- a/src/common/model/blockers/ApertureElement.ts
+++ b/src/common/model/blockers/ApertureElement.ts
@@ -10,9 +10,11 @@
 import { ELEMENT_CATEGORY_BLOCKER, ELEMENT_TYPE_APERTURE } from "../../../OpticsLabStrings.js";
 import { BaseElement } from "../optics/BaseElement.js";
 import {
+  type Bounds,
   dot,
   type Point,
   point,
+  pointsBounds,
   projectPointOntoLine,
   raySegmentIntersection,
   segment,
@@ -79,6 +81,10 @@ export class ApertureElement extends BaseElement {
     this._p2 = p2;
     this._p3 = projectPointOntoLine(p3, p1, p2);
     this._p4 = projectPointOntoLine(p4, p1, p2);
+  }
+
+  public getBounds(): Bounds {
+    return pointsBounds([this.p1, this.p2, this.p3, this.p4]);
   }
 
   public override checkRayIntersection(ray: SimulationRay): IntersectionResult | null {

--- a/src/common/model/detectors/DetectorElement.ts
+++ b/src/common/model/detectors/DetectorElement.ts
@@ -13,6 +13,7 @@ import { DETECTOR_NUM_BINS } from "../../../OpticsLabConstants.js";
 import { ELEMENT_CATEGORY_BLOCKER, ELEMENT_TYPE_DETECTOR } from "../../../OpticsLabStrings.js";
 import { BaseSegmentElement } from "../optics/BaseSegmentElement.js";
 import {
+  type Bounds,
   circle,
   circumcenter,
   distance,
@@ -21,6 +22,7 @@ import {
   normalize,
   type Point,
   point,
+  pointsBounds,
   rayCircleIntersections,
   subtract,
 } from "../optics/Geometry.js";
@@ -127,6 +129,10 @@ export class DetectorElement extends BaseSegmentElement {
   /** Advance the acquisition timer by dt seconds. Returns true when acquisition finishes. */
   public stepAcquisition(dt: number): boolean {
     return this.acquisition.step(dt);
+  }
+
+  public override getBounds(): Bounds {
+    return pointsBounds([this.p1, this.p2, this.p3]);
   }
 
   public override checkRayIntersection(ray: SimulationRay): IntersectionResult | null {

--- a/src/common/model/fiber/FiberOpticElement.ts
+++ b/src/common/model/fiber/FiberOpticElement.ts
@@ -25,6 +25,8 @@
 import {
   DEFAULT_REFRACTIVE_INDEX,
   FIBER_OPTIC_CORE_REFRACTIVE_INDEX,
+  FIBER_OPTIC_CRITICAL_BEND_RADIUS,
+  FIBER_OPTIC_DEFAULT_BEND_LOSS_COEFF,
   FIBER_OPTIC_DEFAULT_OUTER_RADIUS_M,
 } from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_FIBER_CORE_GLASS, ELEMENT_TYPE_FIBER_OPTIC } from "../../../OpticsLabStrings.js";
@@ -57,9 +59,63 @@ export class FiberCoreGlass extends Glass {
   /** The refractive index of the surrounding cladding medium. */
   public outerRefIndex: number;
 
+  /**
+   * Spine curvature samples from the parent FiberOpticElement.
+   * Used to compute local bend loss at intersection points.
+   */
+  public spineCurvatures: Array<{ point: Point; curvature: number }> = [];
+
+  /** Bend loss coefficient (dB/m per 1/R), set by parent FiberOpticElement. */
+  public bendLossCoeff = 0;
+
+  /** Critical bend radius (m), set by parent FiberOpticElement. */
+  public criticalBendRadius = 0.5;
+
   public constructor(coreRefIndex: number, claddingRefIndex: number) {
     super([], coreRefIndex, 0.004, true);
     this.outerRefIndex = claddingRefIndex;
+  }
+
+  /**
+   * Look up the local curvature at a point by finding the nearest spine sample.
+   * Returns the curvature (1/R) at that sample position.
+   */
+  private getLocalCurvature(p: Point): number {
+    if (this.spineCurvatures.length === 0) {
+      return 0;
+    }
+    let bestDistSq = Infinity;
+    let bestCurvature = 0;
+    for (const sample of this.spineCurvatures) {
+      const dx = p.x - sample.point.x;
+      const dy = p.y - sample.point.y;
+      const dSq = dx * dx + dy * dy;
+      if (dSq < bestDistSq) {
+        bestDistSq = dSq;
+        bestCurvature = sample.curvature;
+      }
+    }
+    return bestCurvature;
+  }
+
+  /**
+   * Compute the bend-loss attenuation factor at a given curvature.
+   * Returns a brightness multiplier in (0, 1]. When curvature is below
+   * 1/criticalBendRadius the loss is negligible and returns 1.
+   *
+   * The model uses an exponential attenuation:
+   *   factor = exp(-bendLossCoeff * (κ − κ_critical) / κ_critical)
+   * where κ = curvature = 1/R and κ_critical = 1/criticalBendRadius.
+   */
+  private bendLossFactor(curvature: number): number {
+    if (this.bendLossCoeff <= 0 || this.criticalBendRadius <= 0) {
+      return 1;
+    }
+    const kCritical = 1 / this.criticalBendRadius;
+    if (curvature <= kCritical) {
+      return 1; // no loss above critical bend radius
+    }
+    return Math.exp((-this.bendLossCoeff * (curvature - kCritical)) / kCritical);
   }
 
   public override onRayIncident(
@@ -90,7 +146,25 @@ export class FiberCoreGlass extends Glass {
       normal = { x: -normal.x, y: -normal.y };
     }
 
-    return this.refractRay(ray, intersection.point, normal, n1, config?.partialReflectionEnabled ?? true);
+    const result = this.refractRay(ray, intersection.point, normal, n1, config?.partialReflectionEnabled ?? true);
+
+    // Apply bend loss attenuation to outgoing rays at tight bends.
+    const curvature = this.getLocalCurvature(intersection.point);
+    const factor = this.bendLossFactor(curvature);
+    if (factor < 1) {
+      if (result.outgoingRay) {
+        result.outgoingRay.brightnessS *= factor;
+        result.outgoingRay.brightnessP *= factor;
+      }
+      if (result.newRays) {
+        for (const r of result.newRays) {
+          r.brightnessS *= factor;
+          r.brightnessP *= factor;
+        }
+      }
+    }
+
+    return result;
   }
 
   /** Never serialized independently — the parent FiberOpticElement owns serialization. */
@@ -134,6 +208,22 @@ function crTangent(p0: Point, p1: Point, p2: Point, p3: Point, t: number): Point
   return {
     x: d0 * p0.x + d1 * p1.x + d2 * p2.x + d3 * p3.x,
     y: d0 * p0.y + d1 * p1.y + d2 * p2.y + d3 * p3.y,
+  };
+}
+
+/**
+ * Second derivative d²P/dt² of the Catmull–Rom segment, evaluated at t.
+ * Used for computing local curvature: κ = |x'y'' − y'x''| / (x'² + y'²)^(3/2).
+ */
+function crSecondDerivative(p0: Point, p1: Point, p2: Point, p3: Point, t: number): Point {
+  const tension = TENSION;
+  const dd0 = tension * (-6 * t + 4);
+  const dd1 = 6 * (2 - tension) * t + 2 * (tension - 3);
+  const dd2 = 6 * (tension - 2) * t + 2 * (3 - 2 * tension);
+  const dd3 = tension * (6 * t - 2);
+  return {
+    x: dd0 * p0.x + dd1 * p1.x + dd2 * p2.x + dd3 * p3.x,
+    y: dd0 * p0.y + dd1 * p1.y + dd2 * p2.y + dd3 * p3.y,
   };
 }
 
@@ -195,6 +285,18 @@ export class FiberOpticElement extends Glass {
   }
 
   /**
+   * Bend loss coefficient (dB/m per 1/R). Controls attenuation at tight bends.
+   * Set to 0 to disable bend loss entirely.
+   */
+  public bendLossCoeff: number;
+
+  /**
+   * Critical bend radius (m). Below this radius, bend loss is applied.
+   * Above it, light propagates with negligible loss.
+   */
+  public criticalBendRadius: number;
+
+  /**
    * The inner-core physics element.  Registered in the scene via
    * getPhysicsElements() so the ray tracer handles core–cladding refraction.
    */
@@ -210,6 +312,8 @@ export class FiberOpticElement extends Glass {
     refIndex = DEFAULT_CLADDING_REFRACTIVE_INDEX,
     coreRadiusFraction = 0.45,
     coreRefIndex = FIBER_OPTIC_CORE_REFRACTIVE_INDEX,
+    bendLossCoeff = FIBER_OPTIC_DEFAULT_BEND_LOSS_COEFF,
+    criticalBendRadius = FIBER_OPTIC_CRITICAL_BEND_RADIUS,
   ) {
     super([], refIndex, 0.004, true);
     this.p1 = p1;
@@ -219,18 +323,23 @@ export class FiberOpticElement extends Glass {
     this.p2 = p2;
     this.outerRadius = outerRadius;
     this.coreRadiusFraction = coreRadiusFraction;
+    this.bendLossCoeff = bendLossCoeff;
+    this.criticalBendRadius = criticalBendRadius;
     this.coreGlass = new FiberCoreGlass(coreRefIndex, refIndex);
     this.rebuildPath();
   }
 
   /**
    * Sample the Catmull–Rom spline at N_PER_SEG × 4 + 1 evenly-spaced
-   * parameter values.  Returns { point, tangent } pairs in model space.
+   * parameter values.  Returns { point, tangent, curvature } triples in model space.
    *
    * Phantom end-points are mirrored so the curve interpolates p1 and p2
    * with a smooth tangent defined by the first/last interior control points.
+   *
+   * The curvature κ at each sample is computed from the first and second
+   * derivatives: κ = |x'y'' − y'x''| / (x'² + y'²)^(3/2).
    */
-  public getSamples(): Array<{ point: Point; tangent: Point }> {
+  public getSamples(): Array<{ point: Point; tangent: Point; curvature: number }> {
     const { p1, cp1, cp2, cp3, p2 } = this;
     const ph0: Point = { x: 2 * p1.x - cp1.x, y: 2 * p1.y - cp1.y };
     const ph4: Point = { x: 2 * p2.x - cp3.x, y: 2 * p2.y - cp3.y };
@@ -243,7 +352,7 @@ export class FiberOpticElement extends Glass {
       [cp2, cp3, p2, ph4],
     ];
 
-    const result: Array<{ point: Point; tangent: Point }> = [];
+    const result: Array<{ point: Point; tangent: Point; curvature: number }> = [];
     for (let s = 0; s < segs.length; s++) {
       const seg = segs[s];
       if (!seg) {
@@ -253,7 +362,13 @@ export class FiberOpticElement extends Glass {
       const kMax = s < segs.length - 1 ? N_PER_SEG : N_PER_SEG + 1;
       for (let k = 0; k < kMax; k++) {
         const t = k / N_PER_SEG;
-        result.push({ point: crPoint(a, b, c, d, t), tangent: crTangent(a, b, c, d, t) });
+        const tangent = crTangent(a, b, c, d, t);
+        const dd = crSecondDerivative(a, b, c, d, t);
+        const speedSq = tangent.x * tangent.x + tangent.y * tangent.y;
+        const speed = Math.sqrt(speedSq);
+        // κ = |x'y'' − y'x''| / (x'² + y'²)^(3/2)
+        const curvature = speed > 1e-10 ? Math.abs(tangent.x * dd.y - tangent.y * dd.x) / (speedSq * speed) : 0;
+        result.push({ point: crPoint(a, b, c, d, t), tangent, curvature });
       }
     }
     return result;
@@ -263,6 +378,7 @@ export class FiberOpticElement extends Glass {
    * Rebuild both ribbon polygon paths (cladding and core) from the current
    * spline geometry.  Also syncs coreGlass.outerRefIndex to match refIndex
    * so that a cladding-index edit is immediately reflected at the core boundary.
+   * Stores per-sample curvature on the core glass for bend loss computation.
    */
   public rebuildPath(): void {
     const samples = this.getSamples();
@@ -270,6 +386,13 @@ export class FiberOpticElement extends Glass {
     this.coreGlass.path = buildRibbonPath(samples, this.outerRadius * this.coreRadiusFraction);
     // Keep the core's outside-medium index in sync with the cladding.
     this.coreGlass.outerRefIndex = this.refIndex;
+    // Store curvature data and bend loss params on the core glass for ray attenuation.
+    this.coreGlass.spineCurvatures = samples.map((s) => ({
+      point: s.point,
+      curvature: s.curvature,
+    }));
+    this.coreGlass.bendLossCoeff = this.bendLossCoeff;
+    this.coreGlass.criticalBendRadius = this.criticalBendRadius;
   }
 
   /**
@@ -292,6 +415,8 @@ export class FiberOpticElement extends Glass {
       refIndex: this.refIndex,
       coreRadiusFraction: this.coreRadiusFraction,
       coreRefIndex: this.coreRefIndex,
+      bendLossCoeff: this.bendLossCoeff,
+      criticalBendRadius: this.criticalBendRadius,
       id: this.id,
     };
   }

--- a/src/common/model/glass/CircleGlass.ts
+++ b/src/common/model/glass/CircleGlass.ts
@@ -8,6 +8,7 @@
 
 import { ELEMENT_TYPE_CIRCLE_GLASS } from "../../../OpticsLabStrings.js";
 import {
+  type Bounds,
   circle,
   distance,
   normalize,
@@ -38,6 +39,11 @@ export class CircleGlass extends BaseGlass {
 
   private get radius(): number {
     return distance(this.p1, this.p2);
+  }
+
+  public override getBounds(): Bounds {
+    const r = this.radius;
+    return { minX: this.p1.x - r, minY: this.p1.y - r, maxX: this.p1.x + r, maxY: this.p1.y + r };
   }
 
   public override checkRayIntersection(ray: SimulationRay): IntersectionResult | null {

--- a/src/common/model/glass/Glass.ts
+++ b/src/common/model/glass/Glass.ts
@@ -16,6 +16,7 @@
 
 import { ELEMENT_TYPE_GLASS } from "../../../OpticsLabStrings.js";
 import {
+  type Bounds,
   circle,
   distance,
   distanceSquared,
@@ -23,6 +24,7 @@ import {
   type Point,
   perpendicularBisector,
   point,
+  pointsBounds,
   rayCircleIntersections,
   raySegmentIntersection,
   segment,
@@ -75,6 +77,12 @@ export class Glass extends BaseGlass {
   public constructor(path: GlassPathPoint[], refIndex = 1.5, cauchyB = 0.004, partialReflect = true) {
     super(refIndex, cauchyB, partialReflect);
     this.path = path;
+  }
+
+  // ── Bounding box ─────────────────────────────────────────────────────────
+
+  public getBounds(): Bounds {
+    return pointsBounds(this.path);
   }
 
   // ── Ray intersection ─────────────────────────────────────────────────────

--- a/src/common/model/glass/HalfPlaneGlass.ts
+++ b/src/common/model/glass/HalfPlaneGlass.ts
@@ -8,7 +8,7 @@
  */
 
 import { ELEMENT_TYPE_PLANE_GLASS } from "../../../OpticsLabStrings.js";
-import { type Point, point, rayLineIntersection, segment, segmentNormal } from "../optics/Geometry.js";
+import { type Bounds, type Point, point, rayLineIntersection, segment, segmentNormal } from "../optics/Geometry.js";
 import type { IntersectionResult, RayCallConfig, RayInteractionResult, SimulationRay } from "../optics/OpticsTypes.js";
 import { BaseGlass } from "./BaseGlass.js";
 
@@ -23,6 +23,11 @@ export class HalfPlaneGlass extends BaseGlass {
     super(refIndex, 0, true);
     this.p1 = p1;
     this.p2 = p2;
+  }
+
+  /** Half-plane is semi-infinite: return unbounded AABB so no ray is culled. */
+  public getBounds(): Bounds {
+    return { minX: -Infinity, minY: -Infinity, maxX: Infinity, maxY: Infinity };
   }
 
   public override checkRayIntersection(ray: SimulationRay): IntersectionResult | null {

--- a/src/common/model/light-sources/ArcLightSource.ts
+++ b/src/common/model/light-sources/ArcLightSource.ts
@@ -9,7 +9,7 @@
  */
 
 import { ELEMENT_TYPE_ARC_SOURCE } from "../../../OpticsLabStrings.js";
-import type { Point } from "../optics/Geometry.js";
+import type { Bounds, Point } from "../optics/Geometry.js";
 import { normalize, point } from "../optics/Geometry.js";
 import { BRIGHTNESS_CONTINUOUS_THRESHOLD, RAY_DENSITY_SCALE } from "../optics/OpticsConstants.js";
 import type { SimulationRay, ViewMode } from "../optics/OpticsTypes.js";
@@ -44,6 +44,10 @@ export class ArcLightSource extends BaseLightSource {
     this.position = position;
     this.direction = direction;
     this.emissionAngle = emissionAngle;
+  }
+
+  public getBounds(): Bounds {
+    return { minX: this.position.x, minY: this.position.y, maxX: this.position.x, maxY: this.position.y };
   }
 
   public override emitRays(rayDensity: number, _mode: ViewMode, jitter = false): SimulationRay[] {

--- a/src/common/model/light-sources/BeamSource.ts
+++ b/src/common/model/light-sources/BeamSource.ts
@@ -7,8 +7,8 @@
  */
 
 import { ELEMENT_TYPE_BEAM } from "../../../OpticsLabStrings.js";
-import type { Point } from "../optics/Geometry.js";
-import { distance, normalize, point, subtract } from "../optics/Geometry.js";
+import type { Bounds, Point } from "../optics/Geometry.js";
+import { distance, normalize, point, pointsBounds, subtract } from "../optics/Geometry.js";
 import { BEAM_RAY_DENSITY_SCALE, BRIGHTNESS_CONTINUOUS_THRESHOLD } from "../optics/OpticsConstants.js";
 import type { SimulationRay, ViewMode } from "../optics/OpticsTypes.js";
 import { BaseLightSource } from "./BaseLightSource.js";
@@ -26,6 +26,10 @@ export class BeamSource extends BaseLightSource {
     super(brightness, wavelength);
     this.p1 = p1;
     this.p2 = p2;
+  }
+
+  public getBounds(): Bounds {
+    return pointsBounds([this.p1, this.p2]);
   }
 
   public override emitRays(rayDensity: number, _mode: ViewMode, jitter = false): SimulationRay[] {

--- a/src/common/model/light-sources/ContinuousSpectrumSource.ts
+++ b/src/common/model/light-sources/ContinuousSpectrumSource.ts
@@ -23,8 +23,8 @@ import {
   CONT_SPECTRUM_DEFAULT_WL_STEP_NM,
 } from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_CONTINUOUS_SPECTRUM_SOURCE } from "../../../OpticsLabStrings.js";
-import type { Point } from "../optics/Geometry.js";
-import { normalize, point, subtract } from "../optics/Geometry.js";
+import type { Bounds, Point } from "../optics/Geometry.js";
+import { normalize, point, pointsBounds, subtract } from "../optics/Geometry.js";
 import { BRIGHTNESS_NORMALIZE, POLARIZATION_SPLIT } from "../optics/OpticsConstants.js";
 import type { SimulationRay, ViewMode } from "../optics/OpticsTypes.js";
 import { BaseLightSource } from "./BaseLightSource.js";
@@ -62,6 +62,10 @@ export class ContinuousSpectrumSource extends BaseLightSource {
     this.wavelengthMin = wavelengthMin;
     this.wavelengthStep = wavelengthStep;
     this.wavelengthMax = wavelengthMax;
+  }
+
+  public getBounds(): Bounds {
+    return pointsBounds([this.p1, this.p2]);
   }
 
   public override emitRays(_rayDensity: number, _mode: ViewMode): SimulationRay[] {

--- a/src/common/model/light-sources/DivergentBeam.ts
+++ b/src/common/model/light-sources/DivergentBeam.ts
@@ -7,8 +7,8 @@
  */
 
 import { ELEMENT_TYPE_DIVERGENT_BEAM } from "../../../OpticsLabStrings.js";
-import type { Point } from "../optics/Geometry.js";
-import { distance, normalize, point, subtract } from "../optics/Geometry.js";
+import type { Bounds, Point } from "../optics/Geometry.js";
+import { distance, normalize, point, pointsBounds, subtract } from "../optics/Geometry.js";
 import {
   BEAM_RAY_DENSITY_SCALE,
   BRIGHTNESS_CONTINUOUS_THRESHOLD,
@@ -42,6 +42,10 @@ export class DivergentBeam extends BaseLightSource {
     this.p1 = p1;
     this.p2 = p2;
     this.emisAngle = emisAngle;
+  }
+
+  public getBounds(): Bounds {
+    return pointsBounds([this.p1, this.p2]);
   }
 
   public override emitRays(rayDensity: number, _mode: ViewMode, jitter = false): SimulationRay[] {

--- a/src/common/model/light-sources/PointSourceElement.ts
+++ b/src/common/model/light-sources/PointSourceElement.ts
@@ -6,7 +6,7 @@
  */
 
 import { ELEMENT_TYPE_POINT_SOURCE } from "../../../OpticsLabStrings.js";
-import type { Point } from "../optics/Geometry.js";
+import type { Bounds, Point } from "../optics/Geometry.js";
 import { point } from "../optics/Geometry.js";
 import { BRIGHTNESS_CONTINUOUS_THRESHOLD, RAY_DENSITY_SCALE } from "../optics/OpticsConstants.js";
 import type { SimulationRay, ViewMode } from "../optics/OpticsTypes.js";
@@ -21,6 +21,10 @@ export class PointSourceElement extends BaseLightSource {
   public constructor(position: Point, brightness = 0.5, wavelength = GREEN_WAVELENGTH) {
     super(brightness, wavelength);
     this.position = position;
+  }
+
+  public getBounds(): Bounds {
+    return { minX: this.position.x, minY: this.position.y, maxX: this.position.x, maxY: this.position.y };
   }
 
   public override emitRays(rayDensity: number, mode: ViewMode, jitter = false): SimulationRay[] {

--- a/src/common/model/light-sources/SingleRaySource.ts
+++ b/src/common/model/light-sources/SingleRaySource.ts
@@ -6,8 +6,8 @@
  */
 
 import { ELEMENT_TYPE_SINGLE_RAY } from "../../../OpticsLabStrings.js";
-import type { Point } from "../optics/Geometry.js";
-import { normalize, point, subtract } from "../optics/Geometry.js";
+import type { Bounds, Point } from "../optics/Geometry.js";
+import { normalize, point, pointsBounds, subtract } from "../optics/Geometry.js";
 import type { SimulationRay, ViewMode } from "../optics/OpticsTypes.js";
 import { BaseLightSource } from "./BaseLightSource.js";
 import { GREEN_WAVELENGTH } from "./LightSourceConstants.js";
@@ -22,6 +22,10 @@ export class SingleRaySource extends BaseLightSource {
     super(brightness, wavelength);
     this.p1 = p1;
     this.p2 = p2;
+  }
+
+  public getBounds(): Bounds {
+    return pointsBounds([this.p1, this.p2]);
   }
 
   public override emitRays(_rayDensity: number, _mode: ViewMode): SimulationRay[] {

--- a/src/common/model/mirrors/AperturedParabolicMirror.ts
+++ b/src/common/model/mirrors/AperturedParabolicMirror.ts
@@ -14,11 +14,13 @@ import { PARABOLIC_MIRROR_SEGMENT_COUNT } from "../../../OpticsLabConstants.js";
 import { ELEMENT_CATEGORY_MIRROR, ELEMENT_TYPE_APERTURED_PARABOLIC_MIRROR } from "../../../OpticsLabStrings.js";
 import { BaseElement } from "../optics/BaseElement.js";
 import {
+  type Bounds,
   distance,
   dot,
   normalize,
   type Point,
   point,
+  pointsBounds,
   raySegmentIntersection,
   segment,
   segmentNormal,
@@ -80,6 +82,10 @@ export class AperturedParabolicMirror extends BaseElement {
       points.push(point(px, py));
     }
     return points;
+  }
+
+  public getBounds(): Bounds {
+    return pointsBounds(this.computePoints());
   }
 
   /**

--- a/src/common/model/mirrors/ArcMirror.ts
+++ b/src/common/model/mirrors/ArcMirror.ts
@@ -10,6 +10,7 @@
 import { ELEMENT_CATEGORY_MIRROR, ELEMENT_TYPE_ARC_MIRROR } from "../../../OpticsLabStrings.js";
 import { BaseElement } from "../optics/BaseElement.js";
 import {
+  type Bounds,
   circle,
   circumcenter,
   distance,
@@ -18,6 +19,7 @@ import {
   normalize,
   type Point,
   point,
+  pointsBounds,
   rayCircleIntersections,
   subtract,
 } from "../optics/Geometry.js";
@@ -82,6 +84,10 @@ export class ArcMirror extends BaseElement {
     // Sagitta: signed distance from M to new p3 along perpDir
     const sagitta = R - Math.sqrt(R * R - h * h);
     this.p3 = point(mx + sagitta * perpX, my + sagitta * perpY);
+  }
+
+  public getBounds(): Bounds {
+    return pointsBounds([this.p1, this.p2, this.p3]);
   }
 
   private getArcGeometry(): { center: Point; radius: number } | null {

--- a/src/common/model/mirrors/ParabolicMirror.ts
+++ b/src/common/model/mirrors/ParabolicMirror.ts
@@ -11,11 +11,13 @@ import { PARABOLIC_MIRROR_SEGMENT_COUNT } from "../../../OpticsLabConstants.js";
 import { ELEMENT_CATEGORY_MIRROR, ELEMENT_TYPE_PARABOLIC_MIRROR } from "../../../OpticsLabStrings.js";
 import { BaseElement } from "../optics/BaseElement.js";
 import {
+  type Bounds,
   distance,
   dot,
   normalize,
   type Point,
   point,
+  pointsBounds,
   raySegmentIntersection,
   segment,
   segmentNormal,
@@ -76,6 +78,10 @@ export class ParabolicMirror extends BaseElement {
       points.push(point(px, py));
     }
     return points;
+  }
+
+  public getBounds(): Bounds {
+    return pointsBounds(this.computePoints());
   }
 
   public override checkRayIntersection(ray: SimulationRay): IntersectionResult | null {

--- a/src/common/model/optics/BaseElement.ts
+++ b/src/common/model/optics/BaseElement.ts
@@ -6,6 +6,7 @@
  * implementations for the OpticalElement interface.
  */
 
+import type { Bounds } from "./Geometry.js";
 import type {
   ElementCategory,
   IntersectionResult,
@@ -43,6 +44,12 @@ export abstract class BaseElement implements OpticalElement {
   }
 
   abstract serialize(): Record<string, unknown>;
+
+  /**
+   * Compute the axis-aligned bounding box of this element's geometry.
+   * Used by the spatial index in the ray tracer for efficient intersection culling.
+   */
+  abstract getBounds(): Bounds;
 
   /**
    * Restore a stable id when deserializing from JSON or PhET-iO state (ids are normally assigned in the constructor).

--- a/src/common/model/optics/BaseSegmentElement.ts
+++ b/src/common/model/optics/BaseSegmentElement.ts
@@ -7,7 +7,16 @@
  */
 
 import { BaseElement } from "./BaseElement.js";
-import { dot, type Point, point, raySegmentIntersection, segment, segmentNormal } from "./Geometry.js";
+import {
+  type Bounds,
+  dot,
+  type Point,
+  point,
+  pointsBounds,
+  raySegmentIntersection,
+  segment,
+  segmentNormal,
+} from "./Geometry.js";
 import type { IntersectionResult, SimulationRay } from "./OpticsTypes.js";
 
 export abstract class BaseSegmentElement extends BaseElement {
@@ -18,6 +27,10 @@ export abstract class BaseSegmentElement extends BaseElement {
     super();
     this.p1 = p1;
     this.p2 = p2;
+  }
+
+  public getBounds(): Bounds {
+    return pointsBounds([this.p1, this.p2]);
   }
 
   public override checkRayIntersection(ray: SimulationRay): IntersectionResult | null {

--- a/src/common/model/optics/CommandHistory.ts
+++ b/src/common/model/optics/CommandHistory.ts
@@ -27,6 +27,85 @@ export interface SceneCommand {
   readonly description: string;
 }
 
+/**
+ * A command that captures a property edit on an arbitrary target object.
+ * Stores the old and new values so that undo restores the property and
+ * redo re-applies the change.
+ *
+ * Usage:
+ *   history.execute(new EditPropertyCommand(element, 'refIndex', oldVal, newVal));
+ */
+export class EditPropertyCommand<T extends Record<string, unknown>, K extends keyof T & string>
+  implements SceneCommand
+{
+  public readonly description: string;
+  private readonly target: T;
+  private readonly property: K;
+  private readonly oldValue: T[K];
+  private readonly newValue: T[K];
+  /** Optional callback invoked after every execute/undo to trigger scene invalidation. */
+  private readonly onChange: (() => void) | undefined;
+
+  public constructor(target: T, property: K, oldValue: T[K], newValue: T[K], onChange?: () => void) {
+    this.target = target;
+    this.property = property;
+    this.oldValue = oldValue;
+    this.newValue = newValue;
+    this.onChange = onChange;
+    this.description = `Edit ${property}: ${String(oldValue)} → ${String(newValue)}`;
+  }
+
+  public execute(): void {
+    this.target[this.property] = this.newValue;
+    this.onChange?.();
+  }
+
+  public undo(): void {
+    this.target[this.property] = this.oldValue;
+    this.onChange?.();
+  }
+}
+
+/**
+ * A command that captures a batch of property edits as a single undoable unit.
+ * Useful for drag operations that change multiple properties simultaneously
+ * (e.g. moving both p1 and p2 of a segment element).
+ */
+export class BatchPropertyCommand implements SceneCommand {
+  public readonly description: string;
+  private readonly entries: Array<{
+    target: Record<string, unknown>;
+    property: string;
+    oldValue: unknown;
+    newValue: unknown;
+  }>;
+  private readonly onChange: (() => void) | undefined;
+
+  public constructor(
+    entries: Array<{ target: Record<string, unknown>; property: string; oldValue: unknown; newValue: unknown }>,
+    description: string,
+    onChange?: () => void,
+  ) {
+    this.entries = entries;
+    this.description = description;
+    this.onChange = onChange;
+  }
+
+  public execute(): void {
+    for (const e of this.entries) {
+      e.target[e.property] = e.newValue;
+    }
+    this.onChange?.();
+  }
+
+  public undo(): void {
+    for (const e of this.entries) {
+      e.target[e.property] = e.oldValue;
+    }
+    this.onChange?.();
+  }
+}
+
 export class CommandHistory {
   private readonly undoStack: SceneCommand[] = [];
   private readonly redoStack: SceneCommand[] = [];
@@ -43,6 +122,19 @@ export class CommandHistory {
   public execute(command: SceneCommand): void {
     this.redoStack.length = 0;
     command.execute(); // throws? command stays off undoStack — caller handles error
+    this.undoStack.push(command);
+    if (this.undoStack.length > MAX_HISTORY_SIZE) {
+      this.undoStack.shift();
+    }
+  }
+
+  /**
+   * Record a command that has already been applied (e.g. by a drag handler).
+   * Unlike execute(), this does NOT call command.execute() — it only pushes
+   * the command onto the undo stack so it can be undone later.
+   */
+  public push(command: SceneCommand): void {
+    this.redoStack.length = 0;
     this.undoStack.push(command);
     if (this.undoStack.length > MAX_HISTORY_SIZE) {
       this.undoStack.shift();

--- a/src/common/model/optics/Geometry.ts
+++ b/src/common/model/optics/Geometry.ts
@@ -419,6 +419,102 @@ export function sampleArcPoints(p1: Point, p2: Point, p3: Point, n: number): Poi
   return arcSamplePoints;
 }
 
+// ── Axis-Aligned Bounding Box ────────────────────────────────────────────────
+
+/** Axis-aligned bounding box (AABB) in model coordinates. */
+export interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+/** Compute the AABB enclosing an array of points. Returns a degenerate zero-area box for empty arrays. */
+export function pointsBounds(points: readonly Point[]): Bounds {
+  if (points.length === 0) {
+    return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+  }
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of points) {
+    if (p.x < minX) {
+      minX = p.x;
+    }
+    if (p.y < minY) {
+      minY = p.y;
+    }
+    if (p.x > maxX) {
+      maxX = p.x;
+    }
+    if (p.y > maxY) {
+      maxY = p.y;
+    }
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+/** Expand a Bounds by a uniform margin on all sides. */
+export function expandBounds(b: Bounds, margin: number): Bounds {
+  return {
+    minX: b.minX - margin,
+    minY: b.minY - margin,
+    maxX: b.maxX + margin,
+    maxY: b.maxY + margin,
+  };
+}
+
+/** Test whether two AABBs overlap. */
+export function boundsOverlap(a: Bounds, b: Bounds): boolean {
+  return a.minX <= b.maxX && a.maxX >= b.minX && a.minY <= b.maxY && a.maxY >= b.minY;
+}
+
+/** Test whether a ray (origin + direction, forward only) can intersect an AABB. */
+export function rayIntersectsBounds(origin: Point, direction: Point, bounds: Bounds): boolean {
+  // Slab method for ray-AABB intersection (forward direction only, t > 0).
+  let tMin = 0;
+  let tMax = Infinity;
+
+  if (Math.abs(direction.x) > 1e-15) {
+    const invDx = 1 / direction.x;
+    let t1 = (bounds.minX - origin.x) * invDx;
+    let t2 = (bounds.maxX - origin.x) * invDx;
+    if (t1 > t2) {
+      const tmp = t1;
+      t1 = t2;
+      t2 = tmp;
+    }
+    tMin = Math.max(tMin, t1);
+    tMax = Math.min(tMax, t2);
+    if (tMin > tMax) {
+      return false;
+    }
+  } else if (origin.x < bounds.minX || origin.x > bounds.maxX) {
+    return false;
+  }
+
+  if (Math.abs(direction.y) > 1e-15) {
+    const invDy = 1 / direction.y;
+    let t1 = (bounds.minY - origin.y) * invDy;
+    let t2 = (bounds.maxY - origin.y) * invDy;
+    if (t1 > t2) {
+      const tmp = t1;
+      t1 = t2;
+      t2 = tmp;
+    }
+    tMin = Math.max(tMin, t1);
+    tMax = Math.min(tMax, t2);
+    if (tMin > tMax) {
+      return false;
+    }
+  } else if (origin.y < bounds.minY || origin.y > bounds.maxY) {
+    return false;
+  }
+
+  return true;
+}
+
 // ── Fresnel Equations ────────────────────────────────────────────────────────
 
 /**

--- a/src/common/model/optics/OpticsScene.ts
+++ b/src/common/model/optics/OpticsScene.ts
@@ -8,9 +8,10 @@
 
 import { BooleanProperty, Emitter, Multilink, NumberProperty, Property } from "scenerystack/axon";
 import { Range } from "scenerystack/dot";
-import { CommandHistory, type SceneCommand } from "./CommandHistory.js";
+import { BatchPropertyCommand, CommandHistory, EditPropertyCommand, type SceneCommand } from "./CommandHistory.js";
 
 export type { SceneCommand } from "./CommandHistory.js";
+export { BatchPropertyCommand, EditPropertyCommand } from "./CommandHistory.js";
 
 import {
   IOType,
@@ -323,6 +324,49 @@ export class OpticsScene extends PhetioObject {
     this.snapToGridProperty.reset();
     this.gridSizeProperty.reset();
     this.observerProperty.reset();
+  }
+
+  // ── Property Edit History ────────────────────────────────────────────────
+
+  /**
+   * Record a single property change on an element as an undoable command.
+   * Call this from view-layer drag/edit handlers:
+   *
+   *   scene.recordPropertyEdit(mirror, 'p1', oldP1, newP1);
+   */
+  public recordPropertyEdit<T extends Record<string, unknown>, K extends keyof T & string>(
+    target: T,
+    property: K,
+    oldValue: T[K],
+    newValue: T[K],
+  ): void {
+    const command = new EditPropertyCommand(target, property, oldValue, newValue, () => {
+      this.invalidate();
+      this.sceneChangedEmitter.emit();
+    });
+    // The property is already set to newValue by the caller (drag handler),
+    // so we push directly without re-executing.
+    this.history.push(command);
+  }
+
+  /**
+   * Record a batch of property changes as a single undoable command.
+   * Useful for drag operations that change multiple properties at once.
+   *
+   *   scene.recordBatchEdit([
+   *     { target: mirror, property: 'p1', oldValue: oldP1, newValue: newP1 },
+   *     { target: mirror, property: 'p2', oldValue: oldP2, newValue: newP2 },
+   *   ], 'Move mirror');
+   */
+  public recordBatchEdit(
+    entries: Array<{ target: Record<string, unknown>; property: string; oldValue: unknown; newValue: unknown }>,
+    description: string,
+  ): void {
+    const command = new BatchPropertyCommand(entries, description, () => {
+      this.invalidate();
+      this.sceneChangedEmitter.emit();
+    });
+    this.history.push(command);
   }
 
   // ── Settings (backward-compatible helpers) ─────────────────────────────

--- a/src/common/model/optics/OpticsTypes.ts
+++ b/src/common/model/optics/OpticsTypes.ts
@@ -6,7 +6,7 @@
  */
 
 import { ELEMENT_CATEGORY_LIGHT_SOURCE } from "../../../OpticsLabStrings.js";
-import type { Point } from "./Geometry.js";
+import type { Bounds, Point } from "./Geometry.js";
 
 // ── Ray ──────────────────────────────────────────────────────────────────────
 
@@ -133,6 +133,9 @@ export interface OpticalElement extends IEmitter, IIntersectable, ISerializable 
   readonly type: string;
   /** Display label for the element. */
   readonly category: ElementCategory;
+
+  /** Compute the axis-aligned bounding box of this element's geometry. */
+  getBounds(): Bounds;
 
   /** Release any resources held by this element to prevent memory leaks. */
   dispose(): void;

--- a/src/common/model/optics/RayTracer.ts
+++ b/src/common/model/optics/RayTracer.ts
@@ -42,6 +42,7 @@ import type {
   SimulationResult,
   ViewMode,
 } from "./OpticsTypes.js";
+import { SpatialIndex } from "./SpatialIndex.js";
 
 // ── Traced Ray Segment (for rendering) ───────────────────────────────────────
 
@@ -111,6 +112,7 @@ const DEFAULT_CONFIG: RayTracerConfig = {
 export class RayTracer {
   private readonly elements: OpticalElement[];
   private readonly config: RayTracerConfig;
+  private readonly spatialIndex: SpatialIndex;
 
   public constructor(elements: OpticalElement[], config: Partial<RayTracerConfig> = {}) {
     this.elements = elements;
@@ -119,6 +121,7 @@ export class RayTracer {
       partialReflectionEnabled: this.config.partialReflectionEnabled ?? true,
       lensRimBlockingEnabled: this.config.lensRimBlockingEnabled ?? false,
     };
+    this.spatialIndex = new SpatialIndex(elements);
   }
 
   /**
@@ -294,7 +297,8 @@ export class RayTracer {
   private findNearestIntersection(ray: SimulationRay): IntersectionResult | null {
     let nearest: IntersectionResult | null = null;
 
-    for (const element of this.elements) {
+    const candidates = this.spatialIndex.query(ray.origin, ray.direction);
+    for (const element of candidates) {
       if (element.category === ELEMENT_CATEGORY_LIGHT_SOURCE) {
         continue; // light sources don't interact with rays
       }

--- a/src/common/model/optics/SpatialIndex.ts
+++ b/src/common/model/optics/SpatialIndex.ts
@@ -1,0 +1,213 @@
+/**
+ * SpatialIndex.ts
+ *
+ * A uniform-grid spatial hash for accelerating ray–element intersection tests.
+ * Each element is inserted into every grid cell its bounding box overlaps.
+ * When querying a ray, only cells along the ray path are visited and the
+ * candidate set is deduplicated, reducing intersection tests from O(E) to
+ * O(1) amortized per ray in typical scenes.
+ *
+ * Elements with infinite bounds (e.g. HalfPlaneGlass) are stored in a
+ * separate "unbounded" list and always included in every query.
+ */
+
+import type { Point } from "./Geometry.js";
+import type { OpticalElement } from "./OpticsTypes.js";
+
+/** Default cell size in model units (metres). */
+const DEFAULT_CELL_SIZE = 2.0;
+
+/**
+ * Maximum number of cells to traverse along a ray before falling back to
+ * the full element list. Prevents degenerate rays from traversing the
+ * entire grid.
+ */
+const MAX_TRAVERSAL_STEPS = 200;
+
+export class SpatialIndex {
+  private readonly cellSize: number;
+  private readonly invCellSize: number;
+  private readonly grid = new Map<number, OpticalElement[]>();
+  /** Elements with infinite or degenerate bounds that must always be tested. */
+  private readonly unbounded: OpticalElement[] = [];
+  /** Total number of finite-bounded elements in the index. */
+  private finiteCount = 0;
+  /** Grid bounds (min/max cell coordinates) for ray traversal clamping. */
+  private gridMinCX = 0;
+  private gridMinCY = 0;
+  private gridMaxCX = 0;
+  private gridMaxCY = 0;
+
+  public constructor(elements: OpticalElement[], cellSize = DEFAULT_CELL_SIZE) {
+    this.cellSize = cellSize;
+    this.invCellSize = 1 / cellSize;
+    this.build(elements);
+  }
+
+  /** Number of finite-bounded elements in the index. */
+  public get size(): number {
+    return this.finiteCount;
+  }
+
+  private cellKey(cx: number, cy: number): number {
+    // Cantor-style pairing; shift to positive range to avoid negative-hash issues.
+    // 20_000 is well above any expected grid extent.
+    const a = cx + 10_000;
+    const b = cy + 10_000;
+    return a * 20_001 + b;
+  }
+
+  private build(elements: OpticalElement[]): void {
+    let minCX = Infinity;
+    let minCY = Infinity;
+    let maxCX = -Infinity;
+    let maxCY = -Infinity;
+
+    for (const el of elements) {
+      const b = el.getBounds();
+
+      if (!(Number.isFinite(b.minX) && Number.isFinite(b.maxX) && Number.isFinite(b.minY) && Number.isFinite(b.maxY))) {
+        this.unbounded.push(el);
+        continue;
+      }
+
+      this.finiteCount++;
+      const cxMin = Math.floor(b.minX * this.invCellSize);
+      const cyMin = Math.floor(b.minY * this.invCellSize);
+      const cxMax = Math.floor(b.maxX * this.invCellSize);
+      const cyMax = Math.floor(b.maxY * this.invCellSize);
+
+      if (cxMin < minCX) {
+        minCX = cxMin;
+      }
+      if (cyMin < minCY) {
+        minCY = cyMin;
+      }
+      if (cxMax > maxCX) {
+        maxCX = cxMax;
+      }
+      if (cyMax > maxCY) {
+        maxCY = cyMax;
+      }
+
+      for (let cx = cxMin; cx <= cxMax; cx++) {
+        for (let cy = cyMin; cy <= cyMax; cy++) {
+          const key = this.cellKey(cx, cy);
+          let list = this.grid.get(key);
+          if (!list) {
+            list = [];
+            this.grid.set(key, list);
+          }
+          list.push(el);
+        }
+      }
+    }
+
+    this.gridMinCX = Number.isFinite(minCX) ? minCX : 0;
+    this.gridMinCY = Number.isFinite(minCY) ? minCY : 0;
+    this.gridMaxCX = Number.isFinite(maxCX) ? maxCX : 0;
+    this.gridMaxCY = Number.isFinite(maxCY) ? maxCY : 0;
+  }
+
+  /** Collect all finite-bounded elements (for the fast path with few elements). */
+  private getAllElements(): OpticalElement[] {
+    const all: OpticalElement[] = [...this.unbounded];
+    for (const list of this.grid.values()) {
+      for (const el of list) {
+        if (!all.includes(el)) {
+          all.push(el);
+        }
+      }
+    }
+    return all;
+  }
+
+  /** Collect elements in a single grid cell into the result set. */
+  private collectCell(cx: number, cy: number, seen: Set<string>, result: OpticalElement[]): void {
+    const key = this.cellKey(cx, cy);
+    const list = this.grid.get(key);
+    if (list) {
+      for (const el of list) {
+        if (!seen.has(el.id)) {
+          seen.add(el.id);
+          result.push(el);
+        }
+      }
+    }
+  }
+
+  /** Whether the cell coordinate is outside the grid in the given step direction. */
+  private isOutOfGrid(cx: number, cy: number, stepX: number, stepY: number): boolean {
+    const pastX = (stepX > 0 && cx > this.gridMaxCX) || (stepX < 0 && cx < this.gridMinCX);
+    const pastY = (stepY > 0 && cy > this.gridMaxCY) || (stepY < 0 && cy < this.gridMinCY);
+    return pastX || pastY;
+  }
+
+  /** Whether a cell coordinate is within the grid extent. */
+  private isInGrid(cx: number, cy: number): boolean {
+    return cx >= this.gridMinCX && cx <= this.gridMaxCX && cy >= this.gridMinCY && cy <= this.gridMaxCY;
+  }
+
+  /** Compute DDA axis parameters: initial tMax and tDelta for one axis. */
+  private static ddaAxis(
+    originCoord: number,
+    dirCoord: number,
+    cellCoord: number,
+    cellSize: number,
+  ): { tMax: number; tDelta: number; step: number } {
+    if (dirCoord > 0) {
+      const nextBoundary = (cellCoord + 1) * cellSize;
+      return { tMax: (nextBoundary - originCoord) / dirCoord, tDelta: cellSize / dirCoord, step: 1 };
+    }
+    if (dirCoord < 0) {
+      const nextBoundary = cellCoord * cellSize;
+      return { tMax: (nextBoundary - originCoord) / dirCoord, tDelta: -cellSize / dirCoord, step: -1 };
+    }
+    return { tMax: Infinity, tDelta: Infinity, step: 0 };
+  }
+
+  /**
+   * Query elements whose bounding boxes a ray might intersect.
+   * Uses 2D DDA (Digital Differential Analyzer) grid traversal.
+   *
+   * Returns a deduplicated array of candidate elements (including unbounded ones).
+   */
+  public query(origin: Point, direction: Point): OpticalElement[] {
+    if (this.finiteCount <= 4) {
+      return this.getAllElements();
+    }
+
+    const seen = new Set<string>();
+    const result: OpticalElement[] = [...this.unbounded];
+    for (const el of this.unbounded) {
+      seen.add(el.id);
+    }
+
+    const inv = this.invCellSize;
+    let cx = Math.floor(origin.x * inv);
+    let cy = Math.floor(origin.y * inv);
+
+    const xAxis = SpatialIndex.ddaAxis(origin.x, direction.x, cx, this.cellSize);
+    const yAxis = SpatialIndex.ddaAxis(origin.y, direction.y, cy, this.cellSize);
+    let tMaxX = xAxis.tMax;
+    let tMaxY = yAxis.tMax;
+
+    for (let step = 0; step < MAX_TRAVERSAL_STEPS; step++) {
+      if (this.isInGrid(cx, cy)) {
+        this.collectCell(cx, cy, seen, result);
+      } else if (this.isOutOfGrid(cx, cy, xAxis.step, yAxis.step)) {
+        break;
+      }
+
+      if (tMaxX < tMaxY) {
+        cx += xAxis.step;
+        tMaxX += xAxis.tDelta;
+      } else {
+        cy += yAxis.step;
+        tMaxY += yAxis.tDelta;
+      }
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
Four model enhancements:

1. getBounds() on all optical elements — adds a Bounds interface to Geometry.ts
   and implements axis-aligned bounding boxes on BaseElement, BaseSegmentElement,
   all light sources, mirrors, glass elements, apertures, and detectors.

2. SpatialIndex for RayTracer — uniform-grid spatial hash with DDA ray traversal
   that reduces intersection tests from O(E) to ~O(1) amortized. Unbounded
   elements (e.g. HalfPlaneGlass) are always included in query results.

3. Property-edit undo/redo — EditPropertyCommand and BatchPropertyCommand in
   CommandHistory, plus convenience methods recordPropertyEdit/recordBatchEdit
   on OpticsScene for single and multi-property undoable edits.

4. Fiber optic bend loss — computes curvature from Catmull-Rom spline second
   derivatives, attenuates ray intensity via exponential bend loss model
   exp(-coeff * (κ - κ_critical) / κ_critical) when curvature exceeds the
   critical bend radius threshold.

https://claude.ai/code/session_01HKHwVQg7rgchFZQtv7D6CJ