### PR TITLE
feat(OpticsScene): add duplicateElement() via serialize/deserialize round-trip

### DIFF
--- a/src/common/model/optics/OpticsScene.ts
+++ b/src/common/model/optics/OpticsScene.ts
@@ -332,7 +332,7 @@ export class OpticsScene extends PhetioObject {
     const state = source.serialize() as Record<string, unknown>;
     // Strip the original ID so deserializeElement assigns a fresh one via the
     // auto-increment counter in BaseElement.
-    delete state["id"];
+    state["id"] = undefined;
     OpticsScene.applyOffsetToState(state, offset.x, offset.y);
 
     const clone = deserializeElement(state);
@@ -358,17 +358,17 @@ export class OpticsScene extends PhetioObject {
     }
 
     if (typeof state["x"] === "number") {
-      state["x"] = state["x"] + dx;
+      state["x"] += dx;
     }
     if (typeof state["y"] === "number") {
-      state["y"] = state["y"] + dy;
+      state["y"] += dy;
     }
 
     if (typeof state["cx"] === "number") {
-      state["cx"] = state["cx"] + dx;
+      state["cx"] += dx;
     }
     if (typeof state["cy"] === "number") {
-      state["cy"] = state["cy"] + dy;
+      state["cy"] += dy;
     }
 
     for (const key of ["p1", "p2", "p3", "p4", "cp1", "cp2", "cp3"] as const) {

--- a/src/common/model/optics/OpticsScene.ts
+++ b/src/common/model/optics/OpticsScene.ts
@@ -313,6 +313,83 @@ export class OpticsScene extends PhetioObject {
     this.opticalElementsGroup.clear();
   }
 
+  /**
+   * Deep-clone an existing element via a serialize/deserialize round-trip,
+   * apply an optional position offset, add the clone to the scene (with
+   * undo history), and return it.
+   *
+   * @param id     ID of the element to duplicate.
+   * @param offset Translation applied to every position field of the clone.
+   *               Defaults to (0, 0) — an exact positional copy.
+   * @returns The new element, or `null` when no element with that ID exists.
+   */
+  public duplicateElement(id: string, offset: Point = point(0, 0)): OpticalElement | null {
+    const source = this.getElement(id);
+    if (!source) {
+      return null;
+    }
+
+    const state = source.serialize() as Record<string, unknown>;
+    // Strip the original ID so deserializeElement assigns a fresh one via the
+    // auto-increment counter in BaseElement.
+    delete state["id"];
+    OpticsScene.applyOffsetToState(state, offset.x, offset.y);
+
+    const clone = deserializeElement(state);
+    if (!clone) {
+      return null;
+    }
+
+    this.addElement(clone, true);
+    return clone;
+  }
+
+  /**
+   * Translate all position fields in a serialized element state by (dx, dy).
+   * Handles every coordinate shape used across the element library:
+   *   - scalar `x`/`y`   (PointSource, ArcLightSource)
+   *   - scalar `cx`/`cy` (prisms, dimensional glass)
+   *   - Point objects `p1`…`p4`, `cp1`…`cp3` (most two-endpoint elements)
+   *   - `path` array of `{x, y, …}` (Glass and its subclasses)
+   */
+  private static applyOffsetToState(state: Record<string, unknown>, dx: number, dy: number): void {
+    if (dx === 0 && dy === 0) {
+      return;
+    }
+
+    if (typeof state["x"] === "number") {
+      state["x"] = state["x"] + dx;
+    }
+    if (typeof state["y"] === "number") {
+      state["y"] = state["y"] + dy;
+    }
+
+    if (typeof state["cx"] === "number") {
+      state["cx"] = state["cx"] + dx;
+    }
+    if (typeof state["cy"] === "number") {
+      state["cy"] = state["cy"] + dy;
+    }
+
+    for (const key of ["p1", "p2", "p3", "p4", "cp1", "cp2", "cp3"] as const) {
+      const v = state[key];
+      if (typeof v === "object" && v !== null) {
+        const pt = v as Record<string, unknown>;
+        if (typeof pt["x"] === "number" && typeof pt["y"] === "number") {
+          state[key] = { ...pt, x: pt["x"] + dx, y: pt["y"] + dy };
+        }
+      }
+    }
+
+    if (Array.isArray(state["path"])) {
+      state["path"] = (state["path"] as Array<Record<string, unknown>>).map((pt) => ({
+        ...pt,
+        ...(typeof pt["x"] === "number" ? { x: pt["x"] + dx } : {}),
+        ...(typeof pt["y"] === "number" ? { y: pt["y"] + dy } : {}),
+      }));
+    }
+  }
+
   /** Clear elements, reset all instrumented scene settings to construction defaults, and clear undo history. */
   public resetAll(): void {
     this.clearElements();

--- a/tests/duplicate-element.test.ts
+++ b/tests/duplicate-element.test.ts
@@ -46,7 +46,7 @@ describe("OpticsScene.duplicateElement()", () => {
 
     const clone = scene.duplicateElement(src.id);
     expect(clone).not.toBeNull();
-    expect(clone!.id).not.toBe(src.id);
+    expect(clone?.id).not.toBe(src.id);
   });
 
   it("zero-offset clone has the same serialized state (minus id)", () => {
@@ -58,7 +58,7 @@ describe("OpticsScene.duplicateElement()", () => {
     expect(clone).not.toBeNull();
 
     const srcState = src.serialize();
-    const cloneState = clone!.serialize();
+    const cloneState = clone?.serialize();
     // Every field except the element ID should match.
     expect(cloneState).toMatchObject(srcState);
   });
@@ -71,7 +71,7 @@ describe("OpticsScene.duplicateElement()", () => {
     const clone = scene.duplicateElement(src.id, point(3, -4));
     expect(clone).not.toBeNull();
 
-    const s = clone!.serialize() as Record<string, number>;
+    const s = clone?.serialize() as Record<string, number>;
     expect(s["x"]).toBeCloseTo(8);
     expect(s["y"]).toBeCloseTo(6);
   });
@@ -84,7 +84,7 @@ describe("OpticsScene.duplicateElement()", () => {
     const clone = scene.duplicateElement(src.id, point(5, 5));
     expect(clone).not.toBeNull();
 
-    const s = clone!.serialize() as Record<string, { x: number; y: number }>;
+    const s = clone?.serialize() as Record<string, { x: number; y: number }>;
     expect(s["p1"]).toMatchObject({ x: 5, y: 5 });
     expect(s["p2"]).toMatchObject({ x: 15, y: 5 });
   });
@@ -97,7 +97,7 @@ describe("OpticsScene.duplicateElement()", () => {
     const clone = scene.duplicateElement(src.id, point(2, -3));
     expect(clone).not.toBeNull();
 
-    const s = clone!.serialize() as Record<string, number>;
+    const s = clone?.serialize() as Record<string, number>;
     expect(s["cx"]).toBeCloseTo(2);
     expect(s["cy"]).toBeCloseTo(-3);
   });
@@ -117,7 +117,7 @@ describe("OpticsScene.duplicateElement()", () => {
     const clone = scene.duplicateElement(src.id, point(1, 2));
     expect(clone).not.toBeNull();
 
-    const s = clone!.serialize() as { path: Array<{ x: number; y: number }> };
+    const s = clone?.serialize() as { path: Array<{ x: number; y: number }> };
     expect(s.path[0]).toMatchObject({ x: 1, y: 2 });
     expect(s.path[1]).toMatchObject({ x: 11, y: 2 });
     expect(s.path[2]).toMatchObject({ x: 6, y: 12 });

--- a/tests/duplicate-element.test.ts
+++ b/tests/duplicate-element.test.ts
@@ -1,0 +1,160 @@
+/**
+ * duplicate-element.test.ts
+ *
+ * Unit tests for OpticsScene.duplicateElement().
+ *
+ * Covers:
+ *   1. Returns null for an unknown element ID.
+ *   2. Clone gets a distinct ID from the original.
+ *   3. Zero-offset clone is an exact positional copy (serialize round-trip).
+ *   4. Position offset is applied to scalar x/y fields (PointSource).
+ *   5. Position offset is applied to p1/p2 Point fields (SegmentMirror).
+ *   6. Position offset is applied to cx/cy fields (EquilateralPrism).
+ *   7. Position offset is applied to Glass path vertices.
+ *   8. Clone is added to the scene (element count increases).
+ *   9. The add operation is undo-able via the history stack.
+ *  10. The original element is unchanged after duplication.
+ */
+
+import { Tandem } from "scenerystack/tandem";
+import { describe, expect, it } from "vitest";
+import { EquilateralPrism } from "../src/common/model/glass/EquilateralPrism.js";
+import { Glass } from "../src/common/model/glass/Glass.js";
+import { PointSourceElement } from "../src/common/model/light-sources/PointSourceElement.js";
+import { SegmentMirror } from "../src/common/model/mirrors/SegmentMirror.js";
+import { point } from "../src/common/model/optics/Geometry.js";
+import { OpticsScene } from "../src/common/model/optics/OpticsScene.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeScene(): OpticsScene {
+  return new OpticsScene(Tandem.OPT_OUT);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("OpticsScene.duplicateElement()", () => {
+  it("returns null for an unknown element ID", () => {
+    const scene = makeScene();
+    expect(scene.duplicateElement("does-not-exist")).toBeNull();
+  });
+
+  it("assigns a distinct ID to the clone", () => {
+    const scene = makeScene();
+    const src = new PointSourceElement(point(0, 0), 1, 550);
+    scene.addElement(src, false);
+
+    const clone = scene.duplicateElement(src.id);
+    expect(clone).not.toBeNull();
+    expect(clone!.id).not.toBe(src.id);
+  });
+
+  it("zero-offset clone has the same serialized state (minus id)", () => {
+    const scene = makeScene();
+    const src = new PointSourceElement(point(10, 20), 0.8, 632);
+    scene.addElement(src, false);
+
+    const clone = scene.duplicateElement(src.id);
+    expect(clone).not.toBeNull();
+
+    const srcState = src.serialize();
+    const cloneState = clone!.serialize();
+    // Every field except the element ID should match.
+    expect(cloneState).toMatchObject(srcState);
+  });
+
+  it("applies dx/dy offset to scalar x/y fields (PointSource)", () => {
+    const scene = makeScene();
+    const src = new PointSourceElement(point(5, 10), 1, 550);
+    scene.addElement(src, false);
+
+    const clone = scene.duplicateElement(src.id, point(3, -4));
+    expect(clone).not.toBeNull();
+
+    const s = clone!.serialize() as Record<string, number>;
+    expect(s["x"]).toBeCloseTo(8);
+    expect(s["y"]).toBeCloseTo(6);
+  });
+
+  it("applies offset to p1/p2 Point fields (SegmentMirror)", () => {
+    const scene = makeScene();
+    const src = new SegmentMirror(point(0, 0), point(10, 0));
+    scene.addElement(src, false);
+
+    const clone = scene.duplicateElement(src.id, point(5, 5));
+    expect(clone).not.toBeNull();
+
+    const s = clone!.serialize() as Record<string, { x: number; y: number }>;
+    expect(s["p1"]).toMatchObject({ x: 5, y: 5 });
+    expect(s["p2"]).toMatchObject({ x: 15, y: 5 });
+  });
+
+  it("applies offset to cx/cy fields (EquilateralPrism)", () => {
+    const scene = makeScene();
+    const src = new EquilateralPrism(point(0, 0), 1, 1.5);
+    scene.addElement(src, false);
+
+    const clone = scene.duplicateElement(src.id, point(2, -3));
+    expect(clone).not.toBeNull();
+
+    const s = clone!.serialize() as Record<string, number>;
+    expect(s["cx"]).toBeCloseTo(2);
+    expect(s["cy"]).toBeCloseTo(-3);
+  });
+
+  it("applies offset to all Glass path vertices", () => {
+    const scene = makeScene();
+    const src = new Glass(
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 5, y: 10 },
+      ],
+      1.5,
+    );
+    scene.addElement(src, false);
+
+    const clone = scene.duplicateElement(src.id, point(1, 2));
+    expect(clone).not.toBeNull();
+
+    const s = clone!.serialize() as { path: Array<{ x: number; y: number }> };
+    expect(s.path[0]).toMatchObject({ x: 1, y: 2 });
+    expect(s.path[1]).toMatchObject({ x: 11, y: 2 });
+    expect(s.path[2]).toMatchObject({ x: 6, y: 12 });
+  });
+
+  it("adds the clone to the scene (element count increases)", () => {
+    const scene = makeScene();
+    const src = new PointSourceElement(point(0, 0), 1, 550);
+    scene.addElement(src, false);
+    expect(scene.getAllElements()).toHaveLength(1);
+
+    scene.duplicateElement(src.id);
+    expect(scene.getAllElements()).toHaveLength(2);
+  });
+
+  it("the add is undoable via the history stack", () => {
+    const scene = makeScene();
+    const src = new PointSourceElement(point(0, 0), 1, 550);
+    scene.addElement(src, false);
+
+    scene.duplicateElement(src.id);
+    expect(scene.getAllElements()).toHaveLength(2);
+
+    scene.history.undo();
+    expect(scene.getAllElements()).toHaveLength(1);
+    // Original is still present after undoing the duplicate.
+    expect(scene.getElement(src.id)).toBeDefined();
+  });
+
+  it("does not mutate the original element", () => {
+    const scene = makeScene();
+    const src = new PointSourceElement(point(7, 3), 1, 550);
+    scene.addElement(src, false);
+
+    const beforeState = src.serialize();
+    scene.duplicateElement(src.id, point(100, 100));
+
+    expect(src.serialize()).toMatchObject(beforeState);
+  });
+});


### PR DESCRIPTION
Users can now duplicate any optical element without recreating it from the
carousel. duplicateElement(id, offset?) deep-clones the source element by
serialising its full state, optionally translating every position field
(scalar x/y, cx/cy, Point objects p1–p4/cp1–cp3, and Glass path arrays)
by the supplied offset, then deserialising into a fresh element with a new
auto-generated ID. The clone is added to the scene with full undo/redo
support via the existing CommandHistory infrastructure.

Adds applyOffsetToState() as a private static helper that centralises all
coordinate-shape handling without touching any existing code paths.

10 new tests cover: unknown-ID null return, distinct IDs, exact zero-offset
copy, per-coordinate-shape offset correctness, scene count, undo, and
immutability of the original.

https://claude.ai/code/session_01WXq3BgmY4epgY4UNypukhS