### PR TITLE
Hoist magic numbers, i18n strings, and colors to central registries

### DIFF
--- a/src/OpticsLabColors.ts
+++ b/src/OpticsLabColors.ts
@@ -219,6 +219,50 @@ const OpticsLabColors = {
   // ── Glass border (high-opacity stroke for half-plane boundary line) ─────────
   glassBorderStrokeProperty: profileColor("glassBorderStroke", "rgba(60, 130, 210, 0.95)", "rgba(60, 130, 210, 0.95)"),
 
+  // ── Hit-area fill (invisible but non-null so Scenery includes it in hit-testing) ──
+  /**
+   * Nearly-transparent fill applied to invisible body-drag hit paths.
+   * A non-zero alpha is required so Scenery includes the fill area in
+   * containsPoint() — the path remains visually invisible.
+   */
+  hitAreaFillProperty: profileColor("hitAreaFill", "rgba(0,0,0,0.001)", "rgba(0,0,0,0.001)"),
+
+  // ── Image overlay markers (real / virtual image positions) ─────────────────
+  /** Base fill colour for real-image markers (yellow-orange). */
+  imageRealFillBaseColorProperty: profileColor(
+    "imageRealFillBase",
+    "rgba(255, 200, 0, 0.85)",
+    "rgba(200, 150, 0, 0.85)",
+  ),
+  /** Base stroke colour for real-image markers. */
+  imageRealStrokeBaseColorProperty: profileColor("imageRealStrokeBase", "rgba(200, 150, 0, 1)", "rgba(150, 100, 0, 1)"),
+  /** Label fill for real-image markers. */
+  imageRealLabelFillProperty: profileColor("imageRealLabelFill", "rgba(255, 220, 80, 0.95)", "rgba(180, 130, 0, 0.95)"),
+  /** Base stroke colour for virtual-object markers (red). */
+  imageVirtualObjectStrokeBaseColorProperty: profileColor(
+    "imageVirtualObjectStrokeBase",
+    "rgba(255, 80, 80, 1)",
+    "rgba(200, 40, 40, 1)",
+  ),
+  /** Label fill for virtual-object markers. */
+  imageVirtualObjectLabelFillProperty: profileColor(
+    "imageVirtualObjectLabelFill",
+    "rgba(255, 100, 100, 0.95)",
+    "rgba(200, 50, 50, 0.95)",
+  ),
+  /** Base stroke colour for virtual-image markers (cyan). */
+  imageVirtualStrokeBaseColorProperty: profileColor(
+    "imageVirtualStrokeBase",
+    "rgba(0, 210, 255, 1)",
+    "rgba(0, 150, 200, 1)",
+  ),
+  /** Label fill for virtual-image markers. */
+  imageVirtualLabelFillProperty: profileColor(
+    "imageVirtualLabelFill",
+    "rgba(80, 210, 255, 0.95)",
+    "rgba(0, 130, 180, 0.95)",
+  ),
+
   // ── Measuring tape ──────────────────────────────────────────────────────────
   measuringTapeTextColorProperty: profileColor("measuringTapeTextColor", "white", "black"),
   measuringTapeBackgroundColorProperty: profileColor(

--- a/src/OpticsLabConstants.ts
+++ b/src/OpticsLabConstants.ts
@@ -229,6 +229,18 @@ export const ALIGNMENT_MARK_LINE_DASH = [4, 3];
 
 // ── 9. Glass / lens rendering ─────────────────────────────────────────────────
 
+/**
+ * Fraction of the lens aperture used as the default centre-thickness when
+ * constructing a new SphericalLens.  thickness = aperture × this value.
+ */
+export const SPHERICAL_LENS_THICKNESS_SCALE = 0.3;
+
+/**
+ * Minimum allowed centre-thickness (m) when constructing a new SphericalLens.
+ * Applied as: thickness = max(aperture × SPHERICAL_LENS_THICKNESS_SCALE, this).
+ */
+export const SPHERICAL_LENS_THICKNESS_MIN_M = 0.2;
+
 export const IDEAL_LENS_LINE_WIDTH = 3;
 export const IDEAL_LENS_ARROW_SIZE_M = 0.2;
 /** arrowPath lineWidth = IDEAL_LENS_LINE_WIDTH * this factor. */
@@ -365,6 +377,13 @@ export const GRATING_LINES_DENSITY_MAX = 2500;
 export const GRATING_DUTY_CYCLE_MIN = 0.01;
 export const GRATING_DUTY_CYCLE_MAX = 0.99;
 
+/**
+ * Minimum normalised sinc² intensity for a diffraction order to be emitted.
+ * Orders below this threshold are discarded to avoid flooding the scene with
+ * near-zero-brightness rays.
+ */
+export const GRATING_MIN_DIFFRACTION_INTENSITY = 0.001;
+
 /** Number of groove ticks drawn on the transmission grating visual. */
 export const TRANSMISSION_GRATING_TICK_COUNT = 12;
 /** Half-length of each tick mark in pixels. */
@@ -389,6 +408,12 @@ export const APERTURED_MIRROR_APERTURE_DEFAULT_M = 0.15;
 export const APERTURED_MIRROR_APERTURE_MIN_M = 0.0;
 /** Maximum aperture half-width (m) for the slider. */
 export const APERTURED_MIRROR_APERTURE_MAX_M = 0.5;
+/**
+ * Maximum fraction of the mirror's chord half-width that the effective
+ * aperture may reach.  Clamping below 1.0 ensures at least a sliver of
+ * reflecting surface always remains.
+ */
+export const APERTURED_MIRROR_MAX_APERTURE_FRACTION = 0.99;
 
 // ── 14. Detector ─────────────────────────────────────────────────────────────
 
@@ -416,6 +441,14 @@ export const SLAB_GLASS_DEFAULT_HEIGHT_M = 0.3;
 export const DOVE_PRISM_DEFAULT_WIDTH_M = 0.78;
 export const DOVE_PRISM_DEFAULT_HEIGHT_M = 0.36;
 export const EQUILATERAL_PRISM_DEFAULT_SIZE_M = 0.5;
+/** Default leg length (m) for newly created RightAnglePrism instances. */
+export const RIGHT_ANGLE_PRISM_DEFAULT_LEG_LENGTH_M = 0.54;
+/** Default leg length (m) for newly created PorroPrism instances. */
+export const PORRO_PRISM_DEFAULT_LEG_LENGTH_M = 0.6;
+/** Default width (m) for newly created ParallelogramPrism instances. */
+export const PARALLELOGRAM_PRISM_DEFAULT_WIDTH_M = 0.54;
+/** Default height (m) for newly created ParallelogramPrism instances. */
+export const PARALLELOGRAM_PRISM_DEFAULT_HEIGHT_M = 0.42;
 
 // ── 15. ContinuousSpectrumSource defaults ────────────────────────────────────
 
@@ -437,6 +470,11 @@ export const FIBER_OPTIC_DEFAULT_OUTER_RADIUS_M = 0.04;
 export const FIBER_OPTIC_OUTER_RADIUS_MIN_M = 0.01;
 /** Maximum allowed outer radius (m). */
 export const FIBER_OPTIC_OUTER_RADIUS_MAX_M = 0.25;
+/**
+ * Default core-radius fraction for new FiberOpticElement instances.
+ * coreRadius = outerRadius × this value.
+ */
+export const FIBER_CORE_RADIUS_FRACTION_DEFAULT = 0.45;
 
 // ── 17. Carousel ─────────────────────────────────────────────────────────────
 

--- a/src/common/model/fiber/FiberOpticElement.ts
+++ b/src/common/model/fiber/FiberOpticElement.ts
@@ -23,7 +23,9 @@
  */
 
 import {
+  DEFAULT_CAUCHY_B,
   DEFAULT_REFRACTIVE_INDEX,
+  FIBER_CORE_RADIUS_FRACTION_DEFAULT,
   FIBER_OPTIC_CORE_REFRACTIVE_INDEX,
   FIBER_OPTIC_CRITICAL_BEND_RADIUS,
   FIBER_OPTIC_DEFAULT_BEND_LOSS_COEFF,
@@ -69,10 +71,10 @@ export class FiberCoreGlass extends Glass {
   public bendLossCoeff = 0;
 
   /** Critical bend radius (m), set by parent FiberOpticElement. */
-  public criticalBendRadius = 0.5;
+  public criticalBendRadius = FIBER_OPTIC_CRITICAL_BEND_RADIUS;
 
   public constructor(coreRefIndex: number, claddingRefIndex: number) {
-    super([], coreRefIndex, 0.004, true);
+    super([], coreRefIndex, DEFAULT_CAUCHY_B, true);
     this.outerRefIndex = claddingRefIndex;
   }
 
@@ -310,12 +312,12 @@ export class FiberOpticElement extends Glass {
     p2: Point,
     outerRadius = FIBER_OPTIC_DEFAULT_OUTER_RADIUS_M,
     refIndex = DEFAULT_CLADDING_REFRACTIVE_INDEX,
-    coreRadiusFraction = 0.45,
+    coreRadiusFraction = FIBER_CORE_RADIUS_FRACTION_DEFAULT,
     coreRefIndex = FIBER_OPTIC_CORE_REFRACTIVE_INDEX,
     bendLossCoeff = FIBER_OPTIC_DEFAULT_BEND_LOSS_COEFF,
     criticalBendRadius = FIBER_OPTIC_CRITICAL_BEND_RADIUS,
   ) {
-    super([], refIndex, 0.004, true);
+    super([], refIndex, DEFAULT_CAUCHY_B, true);
     this.p1 = p1;
     this.cp1 = cp1;
     this.cp2 = cp2;

--- a/src/common/model/glass/BiconcaveLens.ts
+++ b/src/common/model/glass/BiconcaveLens.ts
@@ -5,6 +5,7 @@
  * Enforces r1 = -|r| and r2 = +|r| (both surfaces curve inward).
  */
 
+import { DEFAULT_REFRACTIVE_INDEX } from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_BICONCAVE_LENS } from "../../../OpticsLabStrings.js";
 import type { Point } from "../optics/Geometry.js";
 import { SphericalLens } from "./SphericalLens.js";
@@ -18,7 +19,7 @@ export class BiconcaveLens extends SphericalLens {
    * @param r - Radius of curvature (positive). Both surfaces use this magnitude.
    * @param refIndex - Refractive index of the lens material.
    */
-  public constructor(p1: Point, p2: Point, r: number, refIndex = 1.5) {
+  public constructor(p1: Point, p2: Point, r: number, refIndex = DEFAULT_REFRACTIVE_INDEX) {
     const rAbs = Math.abs(r);
     super(p1, p2, -rAbs, rAbs, refIndex);
   }

--- a/src/common/model/glass/BiconvexLens.ts
+++ b/src/common/model/glass/BiconvexLens.ts
@@ -5,6 +5,7 @@
  * Enforces r1 = +|r| and r2 = -|r| (both surfaces curve outward).
  */
 
+import { DEFAULT_REFRACTIVE_INDEX } from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_BICONVEX_LENS } from "../../../OpticsLabStrings.js";
 import type { Point } from "../optics/Geometry.js";
 import { SphericalLens } from "./SphericalLens.js";
@@ -18,7 +19,7 @@ export class BiconvexLens extends SphericalLens {
    * @param r - Radius of curvature (positive). Both surfaces use this magnitude.
    * @param refIndex - Refractive index of the lens material.
    */
-  public constructor(p1: Point, p2: Point, r: number, refIndex = 1.5) {
+  public constructor(p1: Point, p2: Point, r: number, refIndex = DEFAULT_REFRACTIVE_INDEX) {
     const rAbs = Math.abs(r);
     super(p1, p2, rAbs, -rAbs, refIndex);
   }

--- a/src/common/model/glass/CircleGlass.ts
+++ b/src/common/model/glass/CircleGlass.ts
@@ -6,6 +6,7 @@
  * Snell's law with Fresnel partial reflections.
  */
 
+import { DEFAULT_REFRACTIVE_INDEX } from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_CIRCLE_GLASS } from "../../../OpticsLabStrings.js";
 import {
   type Bounds,
@@ -30,7 +31,7 @@ export class CircleGlass extends BaseGlass {
   /** A point on the circle boundary. */
   public p2: Point;
 
-  public constructor(p1: Point, p2: Point, refIndex = 1.5) {
+  public constructor(p1: Point, p2: Point, refIndex = DEFAULT_REFRACTIVE_INDEX) {
     // cauchyB=0 preserves current behaviour (no dispersion); partialReflect=true
     super(refIndex, 0, true);
     this.p1 = p1;

--- a/src/common/model/glass/DovePrism.ts
+++ b/src/common/model/glass/DovePrism.ts
@@ -1,4 +1,9 @@
-import { DOVE_PRISM_DEFAULT_HEIGHT_M, DOVE_PRISM_DEFAULT_WIDTH_M } from "../../../OpticsLabConstants.js";
+import {
+  DEFAULT_CAUCHY_B,
+  DEFAULT_REFRACTIVE_INDEX,
+  DOVE_PRISM_DEFAULT_HEIGHT_M,
+  DOVE_PRISM_DEFAULT_WIDTH_M,
+} from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_DOVE_PRISM } from "../../../OpticsLabStrings.js";
 import type { Point } from "../optics/Geometry.js";
 import { DimensionalGlass } from "./DimensionalGlass.js";
@@ -25,8 +30,8 @@ export class DovePrism extends DimensionalGlass {
     center: Point,
     width = DOVE_PRISM_DEFAULT_WIDTH_M,
     height = DOVE_PRISM_DEFAULT_HEIGHT_M,
-    refIndex = 1.5,
-    cauchyB = 0.004,
+    refIndex = DEFAULT_REFRACTIVE_INDEX,
+    cauchyB = DEFAULT_CAUCHY_B,
     partialReflect = true,
   ) {
     super(makeVertices(center.x, center.y, width, height), width, height, refIndex, cauchyB, partialReflect);

--- a/src/common/model/glass/EquilateralPrism.ts
+++ b/src/common/model/glass/EquilateralPrism.ts
@@ -1,4 +1,8 @@
-import { EQUILATERAL_PRISM_DEFAULT_SIZE_M } from "../../../OpticsLabConstants.js";
+import {
+  DEFAULT_CAUCHY_B,
+  DEFAULT_REFRACTIVE_INDEX,
+  EQUILATERAL_PRISM_DEFAULT_SIZE_M,
+} from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_EQUILATERAL_PRISM } from "../../../OpticsLabStrings.js";
 import { type Point, polygonCentroid } from "../optics/Geometry.js";
 import { Glass, type GlassPathPoint } from "./Glass.js";
@@ -20,8 +24,8 @@ export class EquilateralPrism extends Glass {
   public constructor(
     center: Point,
     size = EQUILATERAL_PRISM_DEFAULT_SIZE_M,
-    refIndex = 1.5,
-    cauchyB = 0.004,
+    refIndex = DEFAULT_REFRACTIVE_INDEX,
+    cauchyB = DEFAULT_CAUCHY_B,
     partialReflect = true,
   ) {
     super(makeVertices(center.x, center.y, size), refIndex, cauchyB, partialReflect);

--- a/src/common/model/glass/ParallelogramPrism.ts
+++ b/src/common/model/glass/ParallelogramPrism.ts
@@ -1,3 +1,9 @@
+import {
+  DEFAULT_CAUCHY_B,
+  DEFAULT_REFRACTIVE_INDEX,
+  PARALLELOGRAM_PRISM_DEFAULT_HEIGHT_M,
+  PARALLELOGRAM_PRISM_DEFAULT_WIDTH_M,
+} from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_PARALLELOGRAM_PRISM } from "../../../OpticsLabStrings.js";
 import type { Point } from "../optics/Geometry.js";
 import { DimensionalGlass } from "./DimensionalGlass.js";
@@ -23,10 +29,10 @@ export class ParallelogramPrism extends DimensionalGlass {
 
   public constructor(
     center: Point,
-    width = 0.54,
-    height = 0.42,
-    refIndex = 1.5,
-    cauchyB = 0.004,
+    width = PARALLELOGRAM_PRISM_DEFAULT_WIDTH_M,
+    height = PARALLELOGRAM_PRISM_DEFAULT_HEIGHT_M,
+    refIndex = DEFAULT_REFRACTIVE_INDEX,
+    cauchyB = DEFAULT_CAUCHY_B,
     partialReflect = true,
   ) {
     super(makeVertices(center.x, center.y, width, height), width, height, refIndex, cauchyB, partialReflect);

--- a/src/common/model/glass/PlanoConcaveLens.ts
+++ b/src/common/model/glass/PlanoConcaveLens.ts
@@ -5,6 +5,7 @@
  * Enforces r1 = Infinity (flat) and r2 = +|r| (concave).
  */
 
+import { DEFAULT_REFRACTIVE_INDEX } from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_PLANO_CONCAVE_LENS } from "../../../OpticsLabStrings.js";
 import type { Point } from "../optics/Geometry.js";
 import { SphericalLens } from "./SphericalLens.js";
@@ -18,7 +19,7 @@ export class PlanoConcaveLens extends SphericalLens {
    * @param r - Radius of curvature of the concave surface (positive).
    * @param refIndex - Refractive index of the lens material.
    */
-  public constructor(p1: Point, p2: Point, r: number, refIndex = 1.5) {
+  public constructor(p1: Point, p2: Point, r: number, refIndex = DEFAULT_REFRACTIVE_INDEX) {
     super(p1, p2, Infinity, Math.abs(r), refIndex);
   }
 

--- a/src/common/model/glass/PlanoConvexLens.ts
+++ b/src/common/model/glass/PlanoConvexLens.ts
@@ -5,6 +5,7 @@
  * Enforces r1 = Infinity (flat) and r2 = -|r| (convex).
  */
 
+import { DEFAULT_REFRACTIVE_INDEX } from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_PLANO_CONVEX_LENS } from "../../../OpticsLabStrings.js";
 import type { Point } from "../optics/Geometry.js";
 import { SphericalLens } from "./SphericalLens.js";
@@ -18,7 +19,7 @@ export class PlanoConvexLens extends SphericalLens {
    * @param r - Radius of curvature of the convex surface (positive).
    * @param refIndex - Refractive index of the lens material.
    */
-  public constructor(p1: Point, p2: Point, r: number, refIndex = 1.5) {
+  public constructor(p1: Point, p2: Point, r: number, refIndex = DEFAULT_REFRACTIVE_INDEX) {
     super(p1, p2, Infinity, -Math.abs(r), refIndex);
   }
 

--- a/src/common/model/glass/PorroPrism.ts
+++ b/src/common/model/glass/PorroPrism.ts
@@ -1,3 +1,8 @@
+import {
+  DEFAULT_CAUCHY_B,
+  DEFAULT_REFRACTIVE_INDEX,
+  PORRO_PRISM_DEFAULT_LEG_LENGTH_M,
+} from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_PORRO_PRISM } from "../../../OpticsLabStrings.js";
 import { type Point, polygonCentroid } from "../optics/Geometry.js";
 import { Glass, type GlassPathPoint } from "./Glass.js";
@@ -24,7 +29,13 @@ export class PorroPrism extends Glass {
   public override readonly type: string = ELEMENT_TYPE_PORRO_PRISM;
   public legLength: number;
 
-  public constructor(center: Point, legLength = 0.6, refIndex = 1.5, cauchyB = 0.004, partialReflect = true) {
+  public constructor(
+    center: Point,
+    legLength = PORRO_PRISM_DEFAULT_LEG_LENGTH_M,
+    refIndex = DEFAULT_REFRACTIVE_INDEX,
+    cauchyB = DEFAULT_CAUCHY_B,
+    partialReflect = true,
+  ) {
     super(makeVertices(center.x, center.y, legLength), refIndex, cauchyB, partialReflect);
     this.legLength = legLength;
   }

--- a/src/common/model/glass/RightAnglePrism.ts
+++ b/src/common/model/glass/RightAnglePrism.ts
@@ -1,3 +1,8 @@
+import {
+  DEFAULT_CAUCHY_B,
+  DEFAULT_REFRACTIVE_INDEX,
+  RIGHT_ANGLE_PRISM_DEFAULT_LEG_LENGTH_M,
+} from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_RIGHT_ANGLE_PRISM } from "../../../OpticsLabStrings.js";
 import { type Point, polygonCentroid } from "../optics/Geometry.js";
 import { Glass, type GlassPathPoint } from "./Glass.js";
@@ -15,7 +20,13 @@ export class RightAnglePrism extends Glass {
   public override readonly type: string = ELEMENT_TYPE_RIGHT_ANGLE_PRISM;
   public legLength: number;
 
-  public constructor(center: Point, legLength = 0.54, refIndex = 1.5, cauchyB = 0.004, partialReflect = true) {
+  public constructor(
+    center: Point,
+    legLength = RIGHT_ANGLE_PRISM_DEFAULT_LEG_LENGTH_M,
+    refIndex = DEFAULT_REFRACTIVE_INDEX,
+    cauchyB = DEFAULT_CAUCHY_B,
+    partialReflect = true,
+  ) {
     super(makeVertices(center.x, center.y, legLength), refIndex, cauchyB, partialReflect);
     this.legLength = legLength;
   }

--- a/src/common/model/glass/SphericalLens.ts
+++ b/src/common/model/glass/SphericalLens.ts
@@ -26,7 +26,12 @@
  *   R = ±Infinity → flat surface
  */
 
-import { SPHERICAL_LENS_APERTURE_SEARCH_HALF_EXTENT } from "../../../OpticsLabConstants.js";
+import {
+  DEFAULT_REFRACTIVE_INDEX,
+  SPHERICAL_LENS_APERTURE_SEARCH_HALF_EXTENT,
+  SPHERICAL_LENS_THICKNESS_MIN_M,
+  SPHERICAL_LENS_THICKNESS_SCALE,
+} from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_SPHERICAL_LENS } from "../../../OpticsLabStrings.js";
 import {
   distance,
@@ -55,13 +60,13 @@ export class SphericalLens extends Glass {
    * @param r2 - Radius of curvature of the right surface.
    * @param refIndex - Refractive index of the lens material.
    */
-  public constructor(p1: Point, p2: Point, r1: number, r2: number, refIndex = 1.5) {
+  public constructor(p1: Point, p2: Point, r1: number, r2: number, refIndex = DEFAULT_REFRACTIVE_INDEX) {
     super([], refIndex);
     this.p1 = p1;
     this.p2 = p2;
 
     const aperture = distance(p1, p2);
-    const defaultD = Math.max(aperture * 0.3, 0.2);
+    const defaultD = Math.max(aperture * SPHERICAL_LENS_THICKNESS_SCALE, SPHERICAL_LENS_THICKNESS_MIN_M);
     if (!this.createLensWithDR1R2(defaultD, r1, r2)) {
       this.createDefaultLens();
     }

--- a/src/common/model/gratings/gratingRayInteraction.ts
+++ b/src/common/model/gratings/gratingRayInteraction.ts
@@ -4,7 +4,11 @@
  * they differ only in whether the outgoing ray lies on the −n or +n side of the surface.
  */
 
-import { GRATING_DEFAULT_WAVELENGTH_NM, GRATING_MAX_DIFFRACTION_ORDER } from "../../../OpticsLabConstants.js";
+import {
+  GRATING_DEFAULT_WAVELENGTH_NM,
+  GRATING_MAX_DIFFRACTION_ORDER,
+  GRATING_MIN_DIFFRACTION_INTENSITY,
+} from "../../../OpticsLabConstants.js";
 import { dot, normalize, type Point, point } from "../optics/Geometry.js";
 import type { IntersectionResult, RayInteractionResult, SimulationRay } from "../optics/OpticsTypes.js";
 
@@ -50,7 +54,7 @@ export function gratingRayInteraction(
 
     const arg = m * dutyCycle;
     const intensity = m === 0 ? 1.0 : sincSquared(arg);
-    if (intensity < 0.001) {
+    if (intensity < GRATING_MIN_DIFFRACTION_INTENSITY) {
       continue;
     }
 

--- a/src/common/model/light-sources/ArcLightSource.ts
+++ b/src/common/model/light-sources/ArcLightSource.ts
@@ -8,6 +8,7 @@
  * π/2 = down (positive y-axis), consistent with Math.atan2(dy, dx).
  */
 
+import { DEFAULT_ARC_CONE_HALF_ANGLE_RAD } from "../../../OpticsLabConstants.js";
 import { ELEMENT_TYPE_ARC_SOURCE } from "../../../OpticsLabStrings.js";
 import type { Bounds, Point } from "../optics/Geometry.js";
 import { normalize, point } from "../optics/Geometry.js";
@@ -36,7 +37,7 @@ export class ArcLightSource extends BaseLightSource {
   public constructor(
     position: Point,
     direction = 0,
-    emissionAngle = Math.PI / 6, // 30 degrees
+    emissionAngle = DEFAULT_ARC_CONE_HALF_ANGLE_RAD,
     brightness = 0.5,
     wavelength = GREEN_WAVELENGTH,
   ) {

--- a/src/common/model/mirrors/AperturedParabolicMirror.ts
+++ b/src/common/model/mirrors/AperturedParabolicMirror.ts
@@ -10,7 +10,7 @@
  * measured along the chord direction from the chord midpoint.
  */
 
-import { PARABOLIC_MIRROR_SEGMENT_COUNT } from "../../../OpticsLabConstants.js";
+import { APERTURED_MIRROR_MAX_APERTURE_FRACTION, PARABOLIC_MIRROR_SEGMENT_COUNT } from "../../../OpticsLabConstants.js";
 import { ELEMENT_CATEGORY_MIRROR, ELEMENT_TYPE_APERTURED_PARABOLIC_MIRROR } from "../../../OpticsLabStrings.js";
 import { BaseElement } from "../optics/BaseElement.js";
 import {
@@ -109,7 +109,7 @@ export class AperturedParabolicMirror extends BaseElement {
     const chordLen = distance(this.p1, this.p2);
     const halfAperture = chordLen / 2;
     // Clamp aperture to half the mirror width so it never fully blocks reflection
-    const effectiveHalfWidth = Math.min(this.apertureHalfWidth, halfAperture * 0.99);
+    const effectiveHalfWidth = Math.min(this.apertureHalfWidth, halfAperture * APERTURED_MIRROR_MAX_APERTURE_FRACTION);
 
     let bestT = Infinity;
     let bestHit: { point: Point; segIndex: number } | null = null;

--- a/src/common/view/ImageOverlayNode.ts
+++ b/src/common/view/ImageOverlayNode.ts
@@ -14,6 +14,7 @@
 
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Circle, Node, Text } from "scenerystack/scenery";
+import OpticsLabColors from "../../OpticsLabColors.js";
 import { FONT_BOLD_9PX } from "../../OpticsLabConstants.js";
 import opticsLab from "../../OpticsLabNamespace.js";
 import type { DetectedImage } from "../model/optics/OpticsTypes.js";
@@ -56,37 +57,41 @@ export class ImageOverlayNode extends Node {
       let labelFill: string;
 
       if (img.imageType === "real") {
+        const fillBase = OpticsLabColors.imageRealFillBaseColorProperty.value;
+        const strokeBase = OpticsLabColors.imageRealStrokeBaseColorProperty.value;
         marker = new Circle(MARKER_RADIUS, {
-          fill: `rgba(255, 200, 0, ${(alpha * 0.85).toFixed(3)})`,
-          stroke: `rgba(200, 150, 0, ${alpha.toFixed(3)})`,
+          fill: `rgba(${fillBase.r},${fillBase.g},${fillBase.b},${(alpha * 0.85).toFixed(3)})`,
+          stroke: `rgba(${strokeBase.r},${strokeBase.g},${strokeBase.b},${alpha.toFixed(3)})`,
           lineWidth: 1.5,
           x: vx,
           y: vy,
         });
         labelText = "R";
-        labelFill = "rgba(255, 220, 80, 0.95)";
+        labelFill = OpticsLabColors.imageRealLabelFillProperty.value.toCSS();
       } else if (img.imageType === "virtualObject") {
+        const strokeBase = OpticsLabColors.imageVirtualObjectStrokeBaseColorProperty.value;
         marker = new Circle(MARKER_RADIUS, {
           fill: null,
-          stroke: `rgba(255, 80, 80, ${alpha.toFixed(3)})`,
+          stroke: `rgba(${strokeBase.r},${strokeBase.g},${strokeBase.b},${alpha.toFixed(3)})`,
           lineWidth: 1.5,
           lineDash: [3, 2],
           x: vx,
           y: vy,
         });
         labelText = "VO";
-        labelFill = "rgba(255, 100, 100, 0.95)";
+        labelFill = OpticsLabColors.imageVirtualObjectLabelFillProperty.value.toCSS();
       } else {
+        const strokeBase = OpticsLabColors.imageVirtualStrokeBaseColorProperty.value;
         marker = new Circle(MARKER_RADIUS, {
           fill: null,
-          stroke: `rgba(0, 210, 255, ${alpha.toFixed(3)})`,
+          stroke: `rgba(${strokeBase.r},${strokeBase.g},${strokeBase.b},${alpha.toFixed(3)})`,
           lineWidth: 1.5,
           lineDash: [3, 2],
           x: vx,
           y: vy,
         });
         labelText = "V";
-        labelFill = "rgba(80, 210, 255, 0.95)";
+        labelFill = OpticsLabColors.imageVirtualLabelFillProperty.value.toCSS();
       }
 
       const label = new Text(labelText, {

--- a/src/common/view/ViewHelpers.ts
+++ b/src/common/view/ViewHelpers.ts
@@ -254,7 +254,7 @@ export function createLineBodyHitPath(): Path {
   return new (InteractiveHighlighting(Path))(null, {
     // A very slightly non-zero alpha so the paint is non-null and Scenery
     // includes the fill area in hit-testing, yet the path is visually invisible.
-    fill: "rgba(0,0,0,0.001)",
+    fill: OpticsLabColors.hitAreaFillProperty,
   });
 }
 

--- a/src/common/view/detectors/DetectorView.ts
+++ b/src/common/view/detectors/DetectorView.ts
@@ -100,7 +100,7 @@ export class DetectorView extends BaseOpticalElementView {
       pickable: false,
     });
     this.bodyHitPath = new Path(null, {
-      stroke: "rgba(0,0,0,0.001)",
+      stroke: OpticsLabColors.hitAreaFillProperty,
       lineWidth: LINE_HIT_HALF_WIDTH_PX * 2,
       lineCap: "round",
       lineJoin: "round",

--- a/src/common/view/fiber/FiberOpticView.ts
+++ b/src/common/view/fiber/FiberOpticView.ts
@@ -140,7 +140,7 @@ export class FiberOpticView extends BaseOpticalElementView {
 
     // ── Invisible body hit area ────────────────────────────────────────────
     this.bodyHitPath = new (InteractiveHighlighting(Path))(null, {
-      fill: "rgba(0,0,0,0.001)",
+      fill: OpticsLabColors.hitAreaFillProperty,
     });
 
     // ── Endpoint + control-point handles ──────────────────────────────────

--- a/src/common/view/mirrors/AperturedParabolicMirrorView.ts
+++ b/src/common/view/mirrors/AperturedParabolicMirrorView.ts
@@ -105,13 +105,13 @@ export class AperturedParabolicMirrorView extends BaseOpticalElementView {
       lineWidth: MIRROR_FRONT_WIDTH,
     });
     this.bodyHitPathLeft = new Path(null, {
-      stroke: "rgba(0,0,0,0.001)",
+      stroke: OpticsLabColors.hitAreaFillProperty,
       lineWidth: LINE_HIT_HALF_WIDTH_PX * 2,
       lineCap: "round",
       lineJoin: "round",
     });
     this.bodyHitPathRight = new Path(null, {
-      stroke: "rgba(0,0,0,0.001)",
+      stroke: OpticsLabColors.hitAreaFillProperty,
       lineWidth: LINE_HIT_HALF_WIDTH_PX * 2,
       lineCap: "round",
       lineJoin: "round",

--- a/src/common/view/mirrors/ArcMirrorView.ts
+++ b/src/common/view/mirrors/ArcMirrorView.ts
@@ -65,7 +65,7 @@ export class ArcMirrorView extends BaseOpticalElementView {
       pickable: false,
     });
     this.bodyHitPath = new Path(null, {
-      stroke: "rgba(0,0,0,0.001)",
+      stroke: OpticsLabColors.hitAreaFillProperty,
       lineWidth: LINE_HIT_HALF_WIDTH_PX * 2,
       lineCap: "round",
       lineJoin: "round",

--- a/src/common/view/mirrors/ParabolicMirrorView.ts
+++ b/src/common/view/mirrors/ParabolicMirrorView.ts
@@ -100,7 +100,7 @@ export class ParabolicMirrorView extends BaseOpticalElementView {
       pickable: false,
     });
     this.bodyHitPath = new Path(null, {
-      stroke: "rgba(0,0,0,0.001)",
+      stroke: OpticsLabColors.hitAreaFillProperty,
       lineWidth: LINE_HIT_HALF_WIDTH_PX * 2,
       lineCap: "round",
       lineJoin: "round",


### PR DESCRIPTION
Model magic numbers hoisted to OpticsLabConstants:
- SPHERICAL_LENS_THICKNESS_SCALE / SPHERICAL_LENS_THICKNESS_MIN_M
  (SphericalLens default-thickness calculation, was 0.3 / 0.2)
- APERTURED_MIRROR_MAX_APERTURE_FRACTION
  (aperture clamp in AperturedParabolicMirror, was 0.99)
- FIBER_CORE_RADIUS_FRACTION_DEFAULT
  (FiberOpticElement default coreRadiusFraction, was 0.45)
- GRATING_MIN_DIFFRACTION_INTENSITY
  (grating order intensity threshold, was 0.001)
- RIGHT_ANGLE_PRISM_DEFAULT_LEG_LENGTH_M / PORRO_PRISM_DEFAULT_LEG_LENGTH_M
  (prism constructor defaults, were 0.54 / 0.6)
- PARALLELOGRAM_PRISM_DEFAULT_WIDTH_M / PARALLELOGRAM_PRISM_DEFAULT_HEIGHT_M
  (prism constructor defaults, were 0.54 / 0.42)

Use already-defined constants where they weren't being imported:
- DEFAULT_REFRACTIVE_INDEX (replaces 1.5 in 11 glass/lens constructors)
- DEFAULT_CAUCHY_B (replaces 0.004 in 6 glass constructors + FiberOpticElement)
- DEFAULT_ARC_CONE_HALF_ANGLE_RAD (replaces Math.PI/6 in ArcLightSource)
- FIBER_OPTIC_CRITICAL_BEND_RADIUS (replaces 0.5 FiberCoreGlass field default)

Colors hoisted to OpticsLabColors (with projector-mode variants):
- hitAreaFillProperty – replaces inline "rgba(0,0,0,0.001)" across 6 view files
- imageRealFill/Stroke/LabelFill – real-image marker colours (ImageOverlayNode)
- imageVirtualObject/Stroke/LabelFill – virtual-object marker colours
- imageVirtual/Stroke/LabelFill – virtual-image marker colours

https://claude.ai/code/session_01VM7BNexQn3icfxHVnVQxLd