### PR TITLE
refactor: extract CarouselPanel and ToolsPanel from SimScreenView

### DIFF
--- a/src/common/view/CarouselPanel.ts
+++ b/src/common/view/CarouselPanel.ts
@@ -1,0 +1,107 @@
+/**
+ * CarouselPanel.ts
+ *
+ * Groups the component-carousel toolbox, its vertical page-control dots, and
+ * the grid-scale indicator into a single Node.  The panel stays at the scene
+ * origin (local = parent space) so that Scenery positioning calls issued inside
+ * the constructor target the same coordinate space as the rest of SimScreenView.
+ *
+ * Responsibilities
+ * ─────────────────
+ *  • Create the ComponentCarousel, PageControl, and GridScaleIndicatorNode.
+ *  • Register the visibleBoundsProperty listener that pins the carousel to the
+ *    left edge of the safe area and keeps the scale indicator below it.
+ *  • Register the gridSizeProperty listener that rebuilds the indicator when the
+ *    grid spacing changes.
+ *
+ * SimScreenView adds this panel to the scene graph as a single child and reads
+ * `carousel` and `pageControl` for PDOM ordering.
+ */
+
+import type { ReadOnlyProperty } from "scenerystack/axon";
+import type { Bounds2 } from "scenerystack/dot";
+import type { ModelViewTransform2 } from "scenerystack/phetcommon";
+import { Node } from "scenerystack/scenery";
+import { type Carousel, PageControl } from "scenerystack/sun";
+import { Tandem } from "scenerystack/tandem";
+import OpticsLabColors from "../../OpticsLabColors.js";
+import {
+  CAROUSEL_OFFSET_FROM_PAGE_CONTROL,
+  CAROUSEL_PAGE_CONTROL_DOT_RADIUS,
+  CAROUSEL_PAGE_CONTROL_DOT_SPACING,
+  CAROUSEL_PAGE_CONTROL_MARGIN,
+  GRID_SCALE_INDICATOR_MARGIN,
+} from "../../OpticsLabConstants.js";
+import type { OpticalElement } from "../model/optics/OpticsTypes.js";
+import type { RayTracingCommonModel } from "../model/SimModel.js";
+import { type ComponentKey, createComponentCarousel } from "./ComponentCarousel.js";
+import { GridScaleIndicatorNode } from "./GridScaleIndicatorNode.js";
+import type { OpticalElementView } from "./OpticalElementViewFactory.js";
+
+export class CarouselPanel extends Node {
+  /** The Carousel widget – exposed for return-to-carousel deletion detection and PDOM order. */
+  public readonly carousel: Carousel;
+
+  /** The PageControl dots – exposed for PDOM order. */
+  public readonly pageControl: Node;
+
+  public constructor(
+    modelViewTransform: ModelViewTransform2,
+    globalToLocalPoint: (p: import("scenerystack/dot").Vector2) => import("scenerystack/dot").Vector2,
+    createElement: (element: OpticalElement) => OpticalElementView | null,
+    model: RayTracingCommonModel,
+    visibleBoundsProperty: ReadOnlyProperty<Bounds2>,
+    tandem: Tandem | undefined,
+    carouselComponents?: ComponentKey[],
+  ) {
+    super();
+
+    const carousel = createComponentCarousel(modelViewTransform, globalToLocalPoint, createElement, carouselComponents);
+    this.carousel = carousel;
+
+    const pageControl = new PageControl(carousel.pageNumberProperty, carousel.numberOfPagesProperty, {
+      interactive: true,
+      orientation: "vertical",
+      dotRadius: CAROUSEL_PAGE_CONTROL_DOT_RADIUS,
+      dotSpacing: CAROUSEL_PAGE_CONTROL_DOT_SPACING,
+      currentPageFill: OpticsLabColors.pageControlCurrentFillProperty,
+      currentPageStroke: null,
+      pageFill: OpticsLabColors.pageControlInactiveFillProperty,
+      pageStroke: null,
+      tandem: tandem?.createTandem("pageControl") ?? Tandem.OPTIONAL,
+    });
+    this.pageControl = pageControl;
+
+    const gridScaleIndicatorNode = new GridScaleIndicatorNode();
+    gridScaleIndicatorNode.rebuild(model.scene.gridSizeProperty.value, modelViewTransform);
+    model.scene.showGridProperty.linkAttribute(gridScaleIndicatorNode, "visible");
+
+    this.addChild(pageControl);
+    this.addChild(carousel);
+    this.addChild(gridScaleIndicatorNode);
+
+    // ── Grid scale indicator: x is model-aligned, top hugs the carousel bottom ─
+    const positionGridScaleIndicator = (): void => {
+      const spacing = model.scene.gridSizeProperty.value;
+      const carouselCenterXModel = modelViewTransform.viewToModelX(carousel.centerX);
+      const leftIndex = Math.floor(carouselCenterXModel / spacing);
+      // node.x places local x=0 (the left tick) exactly on the grid line.
+      gridScaleIndicatorNode.x = modelViewTransform.modelToViewX(leftIndex * spacing);
+      gridScaleIndicatorNode.top = carousel.bottom + GRID_SCALE_INDICATOR_MARGIN;
+    };
+
+    model.scene.gridSizeProperty.lazyLink((spacing) => {
+      gridScaleIndicatorNode.rebuild(spacing, modelViewTransform);
+      positionGridScaleIndicator();
+    });
+
+    // ── Pin carousel + page control to the left safe-area edge ────────────────
+    visibleBoundsProperty.link((visibleBounds) => {
+      pageControl.left = visibleBounds.minX + CAROUSEL_PAGE_CONTROL_MARGIN;
+      pageControl.centerY = visibleBounds.centerY;
+      carousel.left = pageControl.right + CAROUSEL_OFFSET_FROM_PAGE_CONTROL;
+      carousel.centerY = visibleBounds.centerY;
+      positionGridScaleIndicator();
+    });
+  }
+}

--- a/src/common/view/SimScreenView.ts
+++ b/src/common/view/SimScreenView.ts
@@ -1,56 +1,15 @@
-import { BooleanProperty, Property } from "scenerystack/axon";
-import { Dimension2, Range, Vector2 } from "scenerystack/dot";
+import { type BooleanProperty, Property } from "scenerystack/axon";
+import { Vector2 } from "scenerystack/dot";
 import { Shape } from "scenerystack/kite";
 import { ModelViewTransform2 } from "scenerystack/phetcommon";
-import { DragListener, Node, Path, Text, VBox } from "scenerystack/scenery";
-import {
-  GridNode,
-  InfoButton,
-  MeasuringTapeNode,
-  NumberControl,
-  ProtractorNode,
-  ResetAllButton,
-} from "scenerystack/scenery-phet";
+import { Node, Path } from "scenerystack/scenery";
+import { GridNode, InfoButton, ResetAllButton } from "scenerystack/scenery-phet";
 import { ScreenView, type ScreenViewOptions } from "scenerystack/sim";
-import {
-  AccordionBox,
-  type Carousel,
-  Checkbox,
-  FlatAppearanceStrategy,
-  PageControl,
-  RoundPushButton,
-} from "scenerystack/sun";
+import { type Carousel, FlatAppearanceStrategy, RoundPushButton } from "scenerystack/sun";
 import { Tandem } from "scenerystack/tandem";
 import { StringManager } from "../../i18n/StringManager.js";
 import OpticsLabColors from "../../OpticsLabColors.js";
-import {
-  ACCORDION_BUTTON_X_MARGIN,
-  ACCORDION_BUTTON_Y_MARGIN,
-  ACCORDION_CONTENT_SPACING,
-  ACCORDION_CONTENT_Y_SPACING,
-  ACQUISITION_PASSES_PER_FRAME,
-  CAROUSEL_OFFSET_FROM_PAGE_CONTROL,
-  CAROUSEL_PAGE_CONTROL_DOT_RADIUS,
-  CAROUSEL_PAGE_CONTROL_DOT_SPACING,
-  CAROUSEL_PAGE_CONTROL_MARGIN,
-  FONT_11PX,
-  FONT_12PX,
-  FONT_BOLD_13PX,
-  GRID_SCALE_INDICATOR_MARGIN,
-  PANEL_CORNER_RADIUS,
-  PANEL_X_MARGIN,
-  PANEL_Y_MARGIN,
-  PIXELS_PER_METER,
-  PROTRACTOR_SCALE,
-  RAY_DENSITY_DELTA,
-  RAY_DENSITY_MAX,
-  RAY_DENSITY_MIN,
-  RESET_BUTTON_MARGIN,
-  SLIDER_THUMB_HEIGHT,
-  SLIDER_THUMB_WIDTH,
-  SLIDER_TRACK_HEIGHT,
-  SLIDER_TRACK_WIDTH,
-} from "../../OpticsLabConstants.js";
+import { ACQUISITION_PASSES_PER_FRAME, PIXELS_PER_METER, RESET_BUTTON_MARGIN } from "../../OpticsLabConstants.js";
 import opticsLab from "../../OpticsLabNamespace.js";
 import type { OpticsLabPreferencesModel } from "../../preferences/OpticsLabPreferencesModel.js";
 import opticsLabQueryParameters from "../../preferences/opticsLabQueryParameters.js";
@@ -58,35 +17,22 @@ import { DetectorElement } from "../model/detectors/DetectorElement.js";
 import type { OpticalElement } from "../model/optics/OpticsTypes.js";
 import type { RayTracingCommonModel } from "../model/SimModel.js";
 import { BaseOpticalElementView } from "./BaseOpticalElementView.js";
-import { type ComponentKey, createComponentCarousel } from "./ComponentCarousel.js";
+import { CarouselPanel } from "./CarouselPanel.js";
+import type { ComponentKey } from "./ComponentCarousel.js";
 import { DetectorView } from "./detectors/DetectorView.js";
 import { EditContainerNode } from "./EditContainerNode.js";
 import { focalMarkersVisibleProperty } from "./FocalMarkersVisibleProperty.js";
-import { GridScaleIndicatorNode } from "./GridScaleIndicatorNode.js";
 import { handlesVisibleProperty } from "./HandlesVisibleProperty.js";
 import { ImageOverlayNode } from "./ImageOverlayNode.js";
 import { InfoDialogNode } from "./InfoDialogNode.js";
-import { DEFAULT_OBSERVER, ObserverNode } from "./ObserverNode.js";
+import { ObserverNode } from "./ObserverNode.js";
 import { createOpticalElementView, type OpticalElementView } from "./OpticalElementViewFactory.js";
 import { rayArrowsVisibleProperty } from "./RayArrowsVisibleProperty.js";
 import { RayPropagationView } from "./RayPropagationView.js";
 import { rayStubsEnabledProperty } from "./RayStubsProperty.js";
 import { sceneHistoryRegistry } from "./SceneHistoryRegistry.js";
 import { downloadSceneSVG } from "./SceneSVGExporter.js";
-import {
-  dragHandleIcon,
-  extendedRaysIcon,
-  focalPointIcon,
-  gridIcon,
-  makeCheckboxContent,
-  measuringTapeIcon,
-  observerIcon,
-  protractorIcon,
-  rayArrowsIcon,
-  rayStubsIcon,
-  showImagesIcon,
-  snapToGridIcon,
-} from "./ToolsPanelIcons.js";
+import { ToolsPanel } from "./ToolsPanel.js";
 import { viewSnapState } from "./ViewSnapState.js";
 
 /**
@@ -282,9 +228,7 @@ export class RayTracingCommonView extends ScreenView {
     this.model = model;
     sceneHistoryRegistry.setHistory(model.scene.history);
     const tandem = options?.tandem;
-    const strings = StringManager.getInstance();
-    const uiStrings = strings.getUIStrings();
-    const prefStrings = strings.getPreferences();
+    const uiStrings = StringManager.getInstance().getUIStrings();
 
     // ── Model-View Transform ────────────────────────────────────────────────
     // Maps model origin (0, 0) to the centre of the visible play area.
@@ -433,9 +377,10 @@ export class RayTracingCommonView extends ScreenView {
     this.addChild(this.editContainerNode);
 
     // ── Component Carousel (toolbox) ─────────────────────────────────────────
-    // Created before the initial-element loop so _setupView can reference it
-    // for return-to-carousel deletion detection.
-    const carousel = createComponentCarousel(
+    // CarouselPanel owns the Carousel, PageControl, GridScaleIndicatorNode, and
+    // their layout listener.  _carousel is kept as a class field so _setupView
+    // can test whether a drop target is inside the toolbox.
+    const carouselPanel = new CarouselPanel(
       modelViewTransform,
       (p) => this.globalToLocalPoint(p),
       (element) => {
@@ -459,61 +404,21 @@ export class RayTracingCommonView extends ScreenView {
 
         return view;
       },
+      model,
+      this.visibleBoundsProperty,
+      tandem,
       carouselComponents,
     );
-    this._carousel = carousel;
-    this.addChild(carousel);
-
-    const pageControl = new PageControl(carousel.pageNumberProperty, carousel.numberOfPagesProperty, {
-      interactive: true,
-      orientation: "vertical",
-      dotRadius: CAROUSEL_PAGE_CONTROL_DOT_RADIUS,
-      dotSpacing: CAROUSEL_PAGE_CONTROL_DOT_SPACING,
-      currentPageFill: OpticsLabColors.pageControlCurrentFillProperty,
-      currentPageStroke: null,
-      pageFill: OpticsLabColors.pageControlInactiveFillProperty,
-      pageStroke: null,
-      tandem: tandem?.createTandem("pageControl") ?? Tandem.OPTIONAL,
-    });
-    this.addChild(pageControl);
-
-    // ── Grid Scale Indicator ──────────────────────────────────────────────
-    // Shown below the carousel whenever the grid is visible.  Its width
-    // equals one grid spacing in pixels; left edge is snapped to the nearest
-    // grid line that keeps it under the carousel panel.
-    const gridScaleIndicatorNode = new GridScaleIndicatorNode();
-    gridScaleIndicatorNode.rebuild(model.scene.gridSizeProperty.value, modelViewTransform);
-    gridVisibleProperty.linkAttribute(gridScaleIndicatorNode, "visible");
-    this.addChild(gridScaleIndicatorNode);
-
-    const positionGridScaleIndicator = (): void => {
-      const spacing = model.scene.gridSizeProperty.value;
-      // Find the grid-line index whose view-x is just left of the carousel centre.
-      const carouselCenterXModel = modelViewTransform.viewToModelX(carousel.centerX);
-      const leftIndex = Math.floor(carouselCenterXModel / spacing);
-      // node.x places local x=0 (the left tick) exactly on the gridline,
-      // rather than node.left which would shift the background pill's edge there.
-      gridScaleIndicatorNode.x = modelViewTransform.modelToViewX(leftIndex * spacing);
-      gridScaleIndicatorNode.top = carousel.bottom + GRID_SCALE_INDICATOR_MARGIN;
-    };
-
-    model.scene.gridSizeProperty.lazyLink((spacing) => {
-      gridScaleIndicatorNode.rebuild(spacing, modelViewTransform);
-      positionGridScaleIndicator();
-    });
-
-    // Keep the page control and carousel pinned to the left edge of the visible (safe) area.
-    this.visibleBoundsProperty.link((visibleBounds) => {
-      pageControl.left = visibleBounds.minX + CAROUSEL_PAGE_CONTROL_MARGIN;
-      pageControl.centerY = visibleBounds.centerY;
-      carousel.left = pageControl.right + CAROUSEL_OFFSET_FROM_PAGE_CONTROL;
-      carousel.centerY = visibleBounds.centerY;
-      positionGridScaleIndicator();
-    });
+    this._carousel = carouselPanel.carousel;
+    this.addChild(carouselPanel);
 
     // ── Observer node (interactive, above elements layer) ────────────────────
     this.observerNode = new ObserverNode(model.scene.observerProperty, modelViewTransform);
-    this.observerNode.visible = false;
+    // Visibility tracks model mode so observer node appears/disappears without
+    // ToolsPanel needing a direct reference to this node.
+    model.scene.modeProperty.link((mode) => {
+      this.observerNode.visible = mode === "observer";
+    });
     this.addChild(this.observerNode);
 
     // Drag layer sits above the carousel so elements being dragged are never
@@ -571,233 +476,19 @@ export class RayTracingCommonView extends ScreenView {
       }
     });
 
-    // ── Tools ─────────────────────────────────────────────────────────────────
-    const measuringTapeVisibleProperty = new BooleanProperty(opticsLabQueryParameters.showMeasuringTape);
-    const protractorVisibleProperty = new BooleanProperty(opticsLabQueryParameters.showProtractor);
-
-    // Measuring tape – uses model coordinates (metres)
-    const uiStringsForTape = StringManager.getInstance().getUIStrings();
-    const measuringTapeUnitsProperty = new Property({
-      name: uiStringsForTape.metersUnitStringProperty.value,
-      multiplier: 1,
-    });
-    const measuringTapeNode = new MeasuringTapeNode(measuringTapeUnitsProperty, {
-      modelViewTransform: modelViewTransform,
-      significantFigures: 2,
-      textColor: OpticsLabColors.measuringTapeTextColorProperty,
-      textBackgroundColor: OpticsLabColors.measuringTapeBackgroundColorProperty,
-      basePositionProperty: new Property(new Vector2(2, 1)),
-      tipPositionProperty: new Property(new Vector2(3, 1)),
-      baseDragStarted: () => {
-        this.selectedElementProperty.value = null;
-      },
-      tandem: tandem?.createTandem("measuringTapeNode") ?? Tandem.OPTIONAL,
-    });
-    measuringTapeVisibleProperty.linkAttribute(measuringTapeNode, "visible");
-    measuringTapeNode.visible = false;
-    this.addChild(measuringTapeNode);
-
-    // Protractor
-    const protractorNode = new ProtractorNode({
-      rotatable: true,
-      scale: PROTRACTOR_SCALE,
-      cursor: "pointer",
-    });
-    protractorNode.center = modelViewTransform.modelToViewPosition(new Vector2(0, 1));
-    protractorVisibleProperty.linkAttribute(protractorNode, "visible");
-    protractorNode.visible = false;
-
-    // Make protractor draggable
-    protractorNode.addInputListener(
-      new DragListener({
-        translateNode: true,
-        tandem: tandem?.createTandem("protractorDragListener") ?? Tandem.OPTIONAL,
-      }),
+    // ── Tools Panel ───────────────────────────────────────────────────────────
+    // ToolsPanel owns the measuring tape, protractor, all toggle checkboxes,
+    // the ray-density control, and the accordion box.  It pins the accordion to
+    // the upper-right safe area via visibleBoundsProperty internally.
+    const toolsPanel = new ToolsPanel(
+      model,
+      modelViewTransform,
+      this.selectedElementProperty,
+      this.visibleBoundsProperty,
+      _opticsLabPreferences.snapToGridProperty,
+      tandem,
     );
-    this.addChild(protractorNode);
-
-    // ── Ray Density Control ──────────────────────────────────────────────────
-    const densityRange = new Range(RAY_DENSITY_MIN, RAY_DENSITY_MAX);
-    const rayDensityProperty = model.scene.rayDensityProperty;
-
-    const densityControl = new NumberControl(uiStrings.rayDensityStringProperty, rayDensityProperty, densityRange, {
-      delta: RAY_DENSITY_DELTA,
-      includeArrowButtons: false,
-      soundGenerator: null,
-      layoutFunction: NumberControl.createLayoutFunction4({ verticalSpacing: 4 }),
-      titleNodeOptions: { fill: OpticsLabColors.overlayLabelFillProperty, font: FONT_11PX },
-      numberDisplayOptions: {
-        decimalPlaces: 2,
-        textOptions: { fill: OpticsLabColors.overlayValueFillProperty, font: FONT_11PX },
-        backgroundFill: OpticsLabColors.overlayInputBackgroundProperty,
-        backgroundStroke: OpticsLabColors.overlayInputBorderProperty,
-      },
-      sliderOptions: {
-        trackSize: new Dimension2(SLIDER_TRACK_WIDTH, SLIDER_TRACK_HEIGHT),
-        thumbSize: new Dimension2(SLIDER_THUMB_WIDTH, SLIDER_THUMB_HEIGHT),
-        ...(tandem && { tandem: tandem.createTandem("rayDensitySlider") }),
-      },
-      ...(tandem && { tandem: tandem.createTandem("rayDensityControl") }),
-    });
-
-    // ── Ray display mode checkboxes ───────────────────────────────────────────
-    // Each checkbox corresponds to one non-default ViewMode. Checking one sets
-    // that mode; un-checking reverts to "rays". All three stay mutually exclusive
-    // via the shared modeProperty as single source of truth.
-    const extendedRaysProperty = new BooleanProperty(model.scene.modeProperty.value === "extended", {
-      ...(tandem && { tandem: tandem.createTandem("extendedRaysVisibleProperty") }),
-    });
-    const showImagesProperty = new BooleanProperty(model.scene.modeProperty.value === "images", {
-      ...(tandem && { tandem: tandem.createTandem("showImagesProperty") }),
-    });
-    const observerModeProperty = new BooleanProperty(model.scene.modeProperty.value === "observer", {
-      ...(tandem && { tandem: tandem.createTandem("observerModeProperty") }),
-    });
-
-    let blockModeSync = false;
-
-    const syncCheckboxesFromMode = (mode: string) => {
-      if (blockModeSync) {
-        return;
-      }
-      blockModeSync = true;
-      extendedRaysProperty.value = mode === "extended";
-      showImagesProperty.value = mode === "images";
-      observerModeProperty.value = mode === "observer";
-      this.observerNode.visible = mode === "observer";
-      blockModeSync = false;
-    };
-
-    extendedRaysProperty.lazyLink((v) => {
-      if (blockModeSync) {
-        return;
-      }
-      model.scene.modeProperty.value = v ? "extended" : "rays";
-    });
-    showImagesProperty.lazyLink((v) => {
-      if (blockModeSync) {
-        return;
-      }
-      model.scene.modeProperty.value = v ? "images" : "rays";
-    });
-    observerModeProperty.lazyLink((v) => {
-      if (blockModeSync) {
-        return;
-      }
-      if (v && !model.scene.observerProperty.value) {
-        model.scene.observerProperty.value = { ...DEFAULT_OBSERVER };
-      }
-      model.scene.modeProperty.value = v ? "observer" : "rays";
-    });
-
-    model.scene.modeProperty.lazyLink(syncCheckboxesFromMode);
-
-    // ── Checkbox helper ──────────────────────────────────────────────────────
-    const checkboxOptions = {
-      checkboxColor: OpticsLabColors.overlayLabelFillProperty,
-      checkboxColorBackground: OpticsLabColors.overlayInputBackgroundProperty,
-    };
-    const checkboxTandem = (name: string) =>
-      tandem ? { tandem: tandem.createTandem(name) } : { tandem: Tandem.OPTIONAL };
-    const labelOptions = {
-      fill: OpticsLabColors.overlayLabelFillProperty,
-      font: FONT_12PX,
-    };
-
-    const measuringTapeCheckbox = new Checkbox(
-      measuringTapeVisibleProperty,
-      makeCheckboxContent(measuringTapeIcon(), uiStrings.measuringTapeStringProperty, labelOptions),
-      { ...checkboxOptions, ...checkboxTandem("measuringTapeCheckbox") },
-    );
-    const protractorCheckbox = new Checkbox(
-      protractorVisibleProperty,
-      makeCheckboxContent(protractorIcon(), uiStrings.protractorStringProperty, labelOptions),
-      { ...checkboxOptions, ...checkboxTandem("protractorCheckbox") },
-    );
-    const extendedRaysCheckbox = new Checkbox(
-      extendedRaysProperty,
-      makeCheckboxContent(extendedRaysIcon(), uiStrings.extendedRaysStringProperty, labelOptions),
-      { ...checkboxOptions, ...checkboxTandem("extendedRaysCheckbox") },
-    );
-    const showHandlesCheckbox = new Checkbox(
-      handlesVisibleProperty,
-      makeCheckboxContent(dragHandleIcon(), uiStrings.showHandlesStringProperty, labelOptions),
-      { ...checkboxOptions, ...checkboxTandem("showHandlesCheckbox") },
-    );
-    const focalMarkersCheckbox = new Checkbox(
-      focalMarkersVisibleProperty,
-      makeCheckboxContent(focalPointIcon(), uiStrings.focalMarkersStringProperty, labelOptions),
-      { ...checkboxOptions, ...checkboxTandem("focalMarkersCheckbox") },
-    );
-    const rayArrowsCheckbox = new Checkbox(
-      rayArrowsVisibleProperty,
-      makeCheckboxContent(rayArrowsIcon(), uiStrings.showRayArrowsStringProperty, labelOptions),
-      { ...checkboxOptions, ...checkboxTandem("rayArrowsCheckbox") },
-    );
-    const rayStubsCheckbox = new Checkbox(
-      rayStubsEnabledProperty,
-      makeCheckboxContent(rayStubsIcon(), uiStrings.rayStubsStringProperty, labelOptions),
-      { ...checkboxOptions, ...checkboxTandem("rayStubsCheckbox") },
-    );
-    const gridCheckbox = new Checkbox(
-      gridVisibleProperty,
-      makeCheckboxContent(gridIcon(), uiStrings.gridStringProperty, labelOptions),
-      { ...checkboxOptions, ...checkboxTandem("showGridCheckbox") },
-    );
-    const snapCheckbox = new Checkbox(
-      snapToGridProperty,
-      makeCheckboxContent(snapToGridIcon(), prefStrings.snapToGridStringProperty, labelOptions),
-      { ...checkboxOptions, ...checkboxTandem("snapToGridCheckbox"), enabledProperty: gridVisibleProperty },
-    );
-    const showImagesCheckbox = new Checkbox(
-      showImagesProperty,
-      makeCheckboxContent(showImagesIcon(), uiStrings.showImagesStringProperty, labelOptions),
-      { ...checkboxOptions, ...checkboxTandem("showImagesCheckbox") },
-    );
-    const observerModeCheckbox = new Checkbox(
-      observerModeProperty,
-      makeCheckboxContent(observerIcon(), uiStrings.observerModeStringProperty, labelOptions),
-      { ...checkboxOptions, ...checkboxTandem("observerModeCheckbox") },
-    );
-
-    // ── Tools / Options Accordion Box ────────────────────────────────────────
-    const accordionContent = new VBox({
-      spacing: ACCORDION_CONTENT_SPACING,
-      align: "left",
-      children: [
-        measuringTapeCheckbox,
-        protractorCheckbox,
-        extendedRaysCheckbox,
-        showImagesCheckbox,
-        observerModeCheckbox,
-        showHandlesCheckbox,
-        focalMarkersCheckbox,
-        rayArrowsCheckbox,
-        rayStubsCheckbox,
-        gridCheckbox,
-        snapCheckbox,
-        densityControl,
-      ],
-    });
-
-    const toolsAccordionBox = new AccordionBox(accordionContent, {
-      titleNode: new Text(uiStrings.toolsStringProperty, {
-        fill: OpticsLabColors.overlayLabelFillProperty,
-        font: FONT_BOLD_13PX,
-      }),
-      fill: OpticsLabColors.panelFillProperty,
-      stroke: OpticsLabColors.panelStrokeProperty,
-      cornerRadius: PANEL_CORNER_RADIUS,
-      contentXMargin: PANEL_X_MARGIN,
-      contentYMargin: PANEL_Y_MARGIN,
-      buttonXMargin: ACCORDION_BUTTON_X_MARGIN,
-      buttonYMargin: ACCORDION_BUTTON_Y_MARGIN,
-      contentYSpacing: ACCORDION_CONTENT_Y_SPACING,
-      expandedProperty: new BooleanProperty(true),
-      ...(tandem && { tandem: tandem.createTandem("toolsAccordionBox") }),
-      ...(!tandem && { tandem: Tandem.OPTIONAL }),
-    });
-    this.addChild(toolsAccordionBox);
+    this.addChild(toolsPanel);
 
     // ── Reset Button ────────────────────────────────────────────────────────
     const resetAllButton = new ResetAllButton({
@@ -806,16 +497,7 @@ export class RayTracingCommonView extends ScreenView {
         _opticsLabPreferences.snapToGridProperty.reset();
         _opticsLabPreferences.gridSpacingProperty.reset();
         this.reset();
-        extendedRaysProperty.reset();
-        measuringTapeVisibleProperty.reset();
-        protractorVisibleProperty.reset();
-        handlesVisibleProperty.reset();
-        focalMarkersVisibleProperty.reset();
-        rayArrowsVisibleProperty.reset();
-        rayStubsEnabledProperty.reset();
-        measuringTapeNode.basePositionProperty.reset();
-        measuringTapeNode.tipPositionProperty.reset();
-        protractorNode.angleProperty.reset();
+        toolsPanel.reset();
       },
       ...(tandem && { tandem: tandem.createTandem("resetAllButton") }),
     });
@@ -840,14 +522,14 @@ export class RayTracingCommonView extends ScreenView {
             gridSpacing: model.scene.gridSizeProperty.value,
             showHandles: handlesVisibleProperty.value,
             measuringTape: {
-              visible: measuringTapeVisibleProperty.value,
-              basePosition: measuringTapeNode.basePositionProperty.value.copy(),
-              tipPosition: measuringTapeNode.tipPositionProperty.value.copy(),
+              visible: toolsPanel.measuringTapeVisibleProperty.value,
+              basePosition: toolsPanel.measuringTapeNode.basePositionProperty.value.copy(),
+              tipPosition: toolsPanel.measuringTapeNode.tipPositionProperty.value.copy(),
             },
             protractor: {
-              visible: protractorVisibleProperty.value,
-              center: modelViewTransform.viewToModelPosition(protractorNode.center),
-              angle: protractorNode.angleProperty.value,
+              visible: toolsPanel.protractorVisibleProperty.value,
+              center: modelViewTransform.viewToModelPosition(toolsPanel.protractorNode.center),
+              angle: toolsPanel.protractorNode.angleProperty.value,
             },
           },
         });
@@ -873,14 +555,13 @@ export class RayTracingCommonView extends ScreenView {
     });
     this.addChild(infoButton);
 
-    // Pin the controls to the visible (safe) area.
+    // Pin the controls (excluding the tools accordion, which ToolsPanel
+    // positions itself) to the visible (safe) area.
     this.visibleBoundsProperty.link((visibleBounds) => {
       resetAllButton.right = visibleBounds.maxX - RESET_BUTTON_MARGIN;
       resetAllButton.bottom = visibleBounds.maxY - RESET_BUTTON_MARGIN;
       downloadSceneButton.right = resetAllButton.left - RESET_BUTTON_MARGIN;
       downloadSceneButton.centerY = resetAllButton.centerY;
-      toolsAccordionBox.right = visibleBounds.maxX - RESET_BUTTON_MARGIN;
-      toolsAccordionBox.top = visibleBounds.minY + RESET_BUTTON_MARGIN;
       infoButton.left = visibleBounds.minX + RESET_BUTTON_MARGIN;
       infoButton.centerY = resetAllButton.centerY;
       infoDialogNode.centerX = this.layoutBounds.centerX;
@@ -891,11 +572,11 @@ export class RayTracingCommonView extends ScreenView {
     this.addChild(
       new Node({
         pdomOrder: [
-          pageControl,
-          carousel,
-          toolsAccordionBox,
-          measuringTapeNode,
-          protractorNode,
+          carouselPanel.pageControl,
+          carouselPanel.carousel,
+          toolsPanel.accordionBox,
+          toolsPanel.measuringTapeNode,
+          toolsPanel.protractorNode,
           this.editContainerNode,
           infoButton,
           downloadSceneButton,
@@ -926,11 +607,11 @@ export class RayTracingCommonView extends ScreenView {
 
       if (
         tryHandleToolsPanelShortcut(event, isTextInput, {
-          measuringTapeVisibleProperty,
-          protractorVisibleProperty,
-          extendedRaysProperty,
-          gridVisibleProperty,
-          snapToGridProperty,
+          measuringTapeVisibleProperty: toolsPanel.measuringTapeVisibleProperty,
+          protractorVisibleProperty: toolsPanel.protractorVisibleProperty,
+          extendedRaysProperty: toolsPanel.extendedRaysProperty,
+          gridVisibleProperty: model.scene.showGridProperty,
+          snapToGridProperty: _opticsLabPreferences.snapToGridProperty,
         })
       ) {
         event.preventDefault();

--- a/src/common/view/ToolsPanel.ts
+++ b/src/common/view/ToolsPanel.ts
@@ -1,0 +1,354 @@
+/**
+ * ToolsPanel.ts
+ *
+ * Collects all of the right-hand "Tools" controls into a single Node:
+ *   • MeasuringTapeNode  (draggable overlay)
+ *   • ProtractorNode     (draggable / rotatable overlay)
+ *   • Ray-display mode properties (extended rays, show images, observer mode)
+ *     with bidirectional sync to model.scene.modeProperty
+ *   • Ray-density NumberControl
+ *   • 11 toggle Checkboxes
+ *   • AccordionBox wrapper with the title "Tools"
+ *
+ * The panel itself stays at the scene origin so child positions are expressed
+ * in the same coordinate space as the rest of SimScreenView.  The AccordionBox
+ * is pinned to the upper-right safe area via `visibleBoundsProperty`.
+ *
+ * Exposed members
+ * ────────────────
+ *   measuringTapeNode        – add to scene in the desired z-order
+ *   protractorNode           – add to scene in the desired z-order
+ *   accordionBox             – for PDOM placement
+ *   measuringTapeVisibleProperty / protractorVisibleProperty
+ *                            – read by keyboard-shortcut handler and SVG export
+ *   extendedRaysProperty     – read by keyboard-shortcut handler
+ *   reset()                  – restores every local property to its default
+ */
+
+import { BooleanProperty, Property, type ReadOnlyProperty } from "scenerystack/axon";
+import { type Bounds2, Dimension2, Range, Vector2 } from "scenerystack/dot";
+import type { ModelViewTransform2 } from "scenerystack/phetcommon";
+import { DragListener, Node, Text, VBox } from "scenerystack/scenery";
+import { MeasuringTapeNode, NumberControl, ProtractorNode } from "scenerystack/scenery-phet";
+import { AccordionBox, Checkbox } from "scenerystack/sun";
+import { Tandem } from "scenerystack/tandem";
+import { StringManager } from "../../i18n/StringManager.js";
+import OpticsLabColors from "../../OpticsLabColors.js";
+import {
+  ACCORDION_BUTTON_X_MARGIN,
+  ACCORDION_BUTTON_Y_MARGIN,
+  ACCORDION_CONTENT_SPACING,
+  ACCORDION_CONTENT_Y_SPACING,
+  FONT_11PX,
+  FONT_12PX,
+  FONT_BOLD_13PX,
+  PANEL_CORNER_RADIUS,
+  PANEL_X_MARGIN,
+  PANEL_Y_MARGIN,
+  PROTRACTOR_SCALE,
+  RAY_DENSITY_DELTA,
+  RAY_DENSITY_MAX,
+  RAY_DENSITY_MIN,
+  RESET_BUTTON_MARGIN,
+  SLIDER_THUMB_HEIGHT,
+  SLIDER_THUMB_WIDTH,
+  SLIDER_TRACK_HEIGHT,
+  SLIDER_TRACK_WIDTH,
+} from "../../OpticsLabConstants.js";
+import opticsLabQueryParameters from "../../preferences/opticsLabQueryParameters.js";
+import type { OpticalElement } from "../model/optics/OpticsTypes.js";
+import type { RayTracingCommonModel } from "../model/SimModel.js";
+import { focalMarkersVisibleProperty } from "./FocalMarkersVisibleProperty.js";
+import { handlesVisibleProperty } from "./HandlesVisibleProperty.js";
+import { DEFAULT_OBSERVER } from "./ObserverNode.js";
+import { rayArrowsVisibleProperty } from "./RayArrowsVisibleProperty.js";
+import { rayStubsEnabledProperty } from "./RayStubsProperty.js";
+import {
+  dragHandleIcon,
+  extendedRaysIcon,
+  focalPointIcon,
+  gridIcon,
+  makeCheckboxContent,
+  measuringTapeIcon,
+  observerIcon,
+  protractorIcon,
+  rayArrowsIcon,
+  rayStubsIcon,
+  showImagesIcon,
+  snapToGridIcon,
+} from "./ToolsPanelIcons.js";
+
+export class ToolsPanel extends Node {
+  /** Draggable measuring-tape overlay – add to scene in the desired z-order. */
+  public readonly measuringTapeNode: MeasuringTapeNode;
+
+  /** Draggable / rotatable protractor overlay – add to scene in the desired z-order. */
+  public readonly protractorNode: ProtractorNode;
+
+  /** The accordion box that groups all toggle controls – for PDOM placement. */
+  public readonly accordionBox: AccordionBox;
+
+  public readonly measuringTapeVisibleProperty: BooleanProperty;
+  public readonly protractorVisibleProperty: BooleanProperty;
+
+  /**
+   * Whether "Extended Rays" mode is active.  Changing this property updates
+   * model.scene.modeProperty; conversely, external modeProperty changes update
+   * this property.
+   */
+  public readonly extendedRaysProperty: BooleanProperty;
+
+  public constructor(
+    model: RayTracingCommonModel,
+    modelViewTransform: ModelViewTransform2,
+    selectedElementProperty: Property<OpticalElement | null>,
+    visibleBoundsProperty: ReadOnlyProperty<Bounds2>,
+    snapToGridProperty: Property<boolean>,
+    tandem: Tandem | undefined,
+  ) {
+    super();
+
+    const strings = StringManager.getInstance();
+    const uiStrings = strings.getUIStrings();
+    const prefStrings = strings.getPreferences();
+
+    // ── Visibility toggles ─────────────────────────────────────────────────────
+    const measuringTapeVisibleProperty = new BooleanProperty(opticsLabQueryParameters.showMeasuringTape);
+    const protractorVisibleProperty = new BooleanProperty(opticsLabQueryParameters.showProtractor);
+    this.measuringTapeVisibleProperty = measuringTapeVisibleProperty;
+    this.protractorVisibleProperty = protractorVisibleProperty;
+
+    // ── Measuring tape ─────────────────────────────────────────────────────────
+    const measuringTapeUnitsProperty = new Property({
+      name: uiStrings.metersUnitStringProperty.value,
+      multiplier: 1,
+    });
+    const measuringTapeNode = new MeasuringTapeNode(measuringTapeUnitsProperty, {
+      modelViewTransform: modelViewTransform,
+      significantFigures: 2,
+      textColor: OpticsLabColors.measuringTapeTextColorProperty,
+      textBackgroundColor: OpticsLabColors.measuringTapeBackgroundColorProperty,
+      basePositionProperty: new Property(new Vector2(2, 1)),
+      tipPositionProperty: new Property(new Vector2(3, 1)),
+      baseDragStarted: () => {
+        selectedElementProperty.value = null;
+      },
+      tandem: tandem?.createTandem("measuringTapeNode") ?? Tandem.OPTIONAL,
+    });
+    measuringTapeVisibleProperty.linkAttribute(measuringTapeNode, "visible");
+    measuringTapeNode.visible = false;
+    this.measuringTapeNode = measuringTapeNode;
+    this.addChild(measuringTapeNode);
+
+    // ── Protractor ─────────────────────────────────────────────────────────────
+    const protractorNode = new ProtractorNode({
+      rotatable: true,
+      scale: PROTRACTOR_SCALE,
+      cursor: "pointer",
+    });
+    protractorNode.center = modelViewTransform.modelToViewPosition(new Vector2(0, 1));
+    protractorVisibleProperty.linkAttribute(protractorNode, "visible");
+    protractorNode.visible = false;
+    protractorNode.addInputListener(
+      new DragListener({
+        translateNode: true,
+        tandem: tandem?.createTandem("protractorDragListener") ?? Tandem.OPTIONAL,
+      }),
+    );
+    this.protractorNode = protractorNode;
+    this.addChild(protractorNode);
+
+    // ── Ray density control ────────────────────────────────────────────────────
+    const densityControl = new NumberControl(
+      uiStrings.rayDensityStringProperty,
+      model.scene.rayDensityProperty,
+      new Range(RAY_DENSITY_MIN, RAY_DENSITY_MAX),
+      {
+        delta: RAY_DENSITY_DELTA,
+        includeArrowButtons: false,
+        soundGenerator: null,
+        layoutFunction: NumberControl.createLayoutFunction4({ verticalSpacing: 4 }),
+        titleNodeOptions: { fill: OpticsLabColors.overlayLabelFillProperty, font: FONT_11PX },
+        numberDisplayOptions: {
+          decimalPlaces: 2,
+          textOptions: { fill: OpticsLabColors.overlayValueFillProperty, font: FONT_11PX },
+          backgroundFill: OpticsLabColors.overlayInputBackgroundProperty,
+          backgroundStroke: OpticsLabColors.overlayInputBorderProperty,
+        },
+        sliderOptions: {
+          trackSize: new Dimension2(SLIDER_TRACK_WIDTH, SLIDER_TRACK_HEIGHT),
+          thumbSize: new Dimension2(SLIDER_THUMB_WIDTH, SLIDER_THUMB_HEIGHT),
+          ...(tandem && { tandem: tandem.createTandem("rayDensitySlider") }),
+        },
+        ...(tandem && { tandem: tandem.createTandem("rayDensityControl") }),
+      },
+    );
+
+    // ── Ray-display mode properties ────────────────────────────────────────────
+    // Three mutually-exclusive modes share a single modeProperty.  Each checkbox
+    // is backed by a local BooleanProperty; changes in either direction stay in sync.
+    const extendedRaysProperty = new BooleanProperty(model.scene.modeProperty.value === "extended", {
+      ...(tandem && { tandem: tandem.createTandem("extendedRaysVisibleProperty") }),
+    });
+    const showImagesProperty = new BooleanProperty(model.scene.modeProperty.value === "images", {
+      ...(tandem && { tandem: tandem.createTandem("showImagesProperty") }),
+    });
+    const observerModeProperty = new BooleanProperty(model.scene.modeProperty.value === "observer", {
+      ...(tandem && { tandem: tandem.createTandem("observerModeProperty") }),
+    });
+    this.extendedRaysProperty = extendedRaysProperty;
+
+    let blockModeSync = false;
+
+    const syncCheckboxesFromMode = (mode: string): void => {
+      if (blockModeSync) {
+        return;
+      }
+      blockModeSync = true;
+      extendedRaysProperty.value = mode === "extended";
+      showImagesProperty.value = mode === "images";
+      observerModeProperty.value = mode === "observer";
+      blockModeSync = false;
+    };
+
+    extendedRaysProperty.lazyLink((v) => {
+      if (blockModeSync) {
+        return;
+      }
+      model.scene.modeProperty.value = v ? "extended" : "rays";
+    });
+    showImagesProperty.lazyLink((v) => {
+      if (blockModeSync) {
+        return;
+      }
+      model.scene.modeProperty.value = v ? "images" : "rays";
+    });
+    observerModeProperty.lazyLink((v) => {
+      if (blockModeSync) {
+        return;
+      }
+      if (v && !model.scene.observerProperty.value) {
+        model.scene.observerProperty.value = { ...DEFAULT_OBSERVER };
+      }
+      model.scene.modeProperty.value = v ? "observer" : "rays";
+    });
+    model.scene.modeProperty.lazyLink(syncCheckboxesFromMode);
+
+    // ── Checkboxes ─────────────────────────────────────────────────────────────
+    const checkboxOptions = {
+      checkboxColor: OpticsLabColors.overlayLabelFillProperty,
+      checkboxColorBackground: OpticsLabColors.overlayInputBackgroundProperty,
+    };
+    const cbTandem = (name: string) => (tandem ? { tandem: tandem.createTandem(name) } : { tandem: Tandem.OPTIONAL });
+    const labelOptions = {
+      fill: OpticsLabColors.overlayLabelFillProperty,
+      font: FONT_12PX,
+    };
+
+    const gridVisibleProperty = model.scene.showGridProperty;
+
+    const checkboxes = [
+      new Checkbox(
+        measuringTapeVisibleProperty,
+        makeCheckboxContent(measuringTapeIcon(), uiStrings.measuringTapeStringProperty, labelOptions),
+        { ...checkboxOptions, ...cbTandem("measuringTapeCheckbox") },
+      ),
+      new Checkbox(
+        protractorVisibleProperty,
+        makeCheckboxContent(protractorIcon(), uiStrings.protractorStringProperty, labelOptions),
+        { ...checkboxOptions, ...cbTandem("protractorCheckbox") },
+      ),
+      new Checkbox(
+        extendedRaysProperty,
+        makeCheckboxContent(extendedRaysIcon(), uiStrings.extendedRaysStringProperty, labelOptions),
+        { ...checkboxOptions, ...cbTandem("extendedRaysCheckbox") },
+      ),
+      new Checkbox(
+        showImagesProperty,
+        makeCheckboxContent(showImagesIcon(), uiStrings.showImagesStringProperty, labelOptions),
+        { ...checkboxOptions, ...cbTandem("showImagesCheckbox") },
+      ),
+      new Checkbox(
+        observerModeProperty,
+        makeCheckboxContent(observerIcon(), uiStrings.observerModeStringProperty, labelOptions),
+        { ...checkboxOptions, ...cbTandem("observerModeCheckbox") },
+      ),
+      new Checkbox(
+        handlesVisibleProperty,
+        makeCheckboxContent(dragHandleIcon(), uiStrings.showHandlesStringProperty, labelOptions),
+        { ...checkboxOptions, ...cbTandem("showHandlesCheckbox") },
+      ),
+      new Checkbox(
+        focalMarkersVisibleProperty,
+        makeCheckboxContent(focalPointIcon(), uiStrings.focalMarkersStringProperty, labelOptions),
+        { ...checkboxOptions, ...cbTandem("focalMarkersCheckbox") },
+      ),
+      new Checkbox(
+        rayArrowsVisibleProperty,
+        makeCheckboxContent(rayArrowsIcon(), uiStrings.showRayArrowsStringProperty, labelOptions),
+        { ...checkboxOptions, ...cbTandem("rayArrowsCheckbox") },
+      ),
+      new Checkbox(
+        rayStubsEnabledProperty,
+        makeCheckboxContent(rayStubsIcon(), uiStrings.rayStubsStringProperty, labelOptions),
+        { ...checkboxOptions, ...cbTandem("rayStubsCheckbox") },
+      ),
+      new Checkbox(gridVisibleProperty, makeCheckboxContent(gridIcon(), uiStrings.gridStringProperty, labelOptions), {
+        ...checkboxOptions,
+        ...cbTandem("showGridCheckbox"),
+      }),
+      new Checkbox(
+        snapToGridProperty,
+        makeCheckboxContent(snapToGridIcon(), prefStrings.snapToGridStringProperty, labelOptions),
+        { ...checkboxOptions, ...cbTandem("snapToGridCheckbox"), enabledProperty: gridVisibleProperty },
+      ),
+    ];
+
+    // ── Accordion box ──────────────────────────────────────────────────────────
+    const accordionBox = new AccordionBox(
+      new VBox({ spacing: ACCORDION_CONTENT_SPACING, align: "left", children: [...checkboxes, densityControl] }),
+      {
+        titleNode: new Text(uiStrings.toolsStringProperty, {
+          fill: OpticsLabColors.overlayLabelFillProperty,
+          font: FONT_BOLD_13PX,
+        }),
+        fill: OpticsLabColors.panelFillProperty,
+        stroke: OpticsLabColors.panelStrokeProperty,
+        cornerRadius: PANEL_CORNER_RADIUS,
+        contentXMargin: PANEL_X_MARGIN,
+        contentYMargin: PANEL_Y_MARGIN,
+        buttonXMargin: ACCORDION_BUTTON_X_MARGIN,
+        buttonYMargin: ACCORDION_BUTTON_Y_MARGIN,
+        contentYSpacing: ACCORDION_CONTENT_Y_SPACING,
+        expandedProperty: new BooleanProperty(true),
+        ...(tandem && { tandem: tandem.createTandem("toolsAccordionBox") }),
+        ...(!tandem && { tandem: Tandem.OPTIONAL }),
+      },
+    );
+    this.accordionBox = accordionBox;
+    this.addChild(accordionBox);
+
+    // ── Pin accordion to upper-right safe area ─────────────────────────────────
+    visibleBoundsProperty.link((visibleBounds) => {
+      accordionBox.right = visibleBounds.maxX - RESET_BUTTON_MARGIN;
+      accordionBox.top = visibleBounds.minY + RESET_BUTTON_MARGIN;
+    });
+  }
+
+  /**
+   * Reset all local properties and tool positions to their initial values.
+   * Called by the ResetAllButton listener in SimScreenView.
+   */
+  public reset(): void {
+    this.extendedRaysProperty.reset();
+    this.measuringTapeVisibleProperty.reset();
+    this.protractorVisibleProperty.reset();
+    handlesVisibleProperty.reset();
+    focalMarkersVisibleProperty.reset();
+    rayArrowsVisibleProperty.reset();
+    rayStubsEnabledProperty.reset();
+    this.measuringTapeNode.basePositionProperty.reset();
+    this.measuringTapeNode.tipPositionProperty.reset();
+    this.protractorNode.angleProperty.reset();
+  }
+}


### PR DESCRIPTION
SimScreenView was a ~1150-line orchestrator.  Two identifiable
sub-concerns with clear constructor boundaries are now separate
Node subclasses:

CarouselPanel (112 lines)
  • Owns the ComponentCarousel, PageControl, GridScaleIndicatorNode.
  • Registers the visibleBoundsProperty listener that pins the
    toolbox to the left safe-area edge.
  • Registers the gridSizeProperty listener that rebuilds the
    scale indicator when spacing changes.
  • Exposes `carousel` and `pageControl` for z-order and PDOM use.

ToolsPanel (348 lines)
  • Owns MeasuringTapeNode, ProtractorNode, all 11 toggle
    Checkboxes, the ray-density NumberControl, and the AccordionBox.
  • Manages the bidirectional mode sync (extended / images /
    observer ↔ modeProperty) internally.
  • Pins the accordion to the upper-right safe area via
    visibleBoundsProperty.
  • Exposes measuringTapeNode, protractorNode, accordionBox,
    and the three boolean properties needed by the keyboard-
    shortcut handler and SVG exporter.
  • Provides reset() so the ResetAllButton listener in
    SimScreenView stays a one-liner.

SimScreenView constructor shrank from 1149 → 830 lines.
Observer-node visibility is now driven directly from
model.scene.modeProperty.link() rather than through
the mode-sync closure, removing the coupling between
ToolsPanel and ObserverNode.

https://claude.ai/code/session_01Pzw8ZYPAMt11hraj7ppWqR