### PR TITLE
Refactor view options into per-screen ViewOptionsModel

### DIFF
--- a/src/OpticsLabConstants.ts
+++ b/src/OpticsLabConstants.ts
@@ -133,6 +133,13 @@ export const RAY_ALPHA_BUCKETS = 20;
 /** Distance threshold (pixels) for image-convergence grid quantization. */
 export const RAY_CONVERGENCE_THRESHOLD = 5;
 
+/** Default length (px) of a ray stub in "ray stubs" display mode. */
+export const RAY_STUB_LENGTH_DEFAULT_PX = 50;
+/** Minimum allowed ray-stub length (px). */
+export const RAY_STUB_LENGTH_MIN_PX = 10;
+/** Maximum allowed ray-stub length (px). */
+export const RAY_STUB_LENGTH_MAX_PX = 200;
+
 // ── 5. Edit-panel UI ──────────────────────────────────────────────────────────
 
 export const PANEL_BOTTOM_MARGIN = 10;

--- a/src/common/view/BaseOpticalElementView.ts
+++ b/src/common/view/BaseOpticalElementView.ts
@@ -114,8 +114,15 @@ export abstract class BaseOpticalElementView extends Node {
    */
   // biome-ignore lint/suspicious/noExplicitAny: linkAttribute requires any for the target object
   protected trackLinkAttribute<T>(property: TReadOnlyProperty<T>, object: any, attributeName: string): void {
-    const handle = property.linkAttribute(object, attributeName) as unknown as (value: unknown) => void;
-    this._linkedAttributes.push({ property: property as TReadOnlyProperty<unknown>, handle });
+    // linkAttribute() returns void, so we must store the listener explicitly.
+    const listener = (value: T) => {
+      object[attributeName] = value;
+    };
+    property.link(listener as unknown as (value: unknown) => void);
+    this._linkedAttributes.push({
+      property: property as TReadOnlyProperty<unknown>,
+      handle: listener as unknown as (value: unknown) => void,
+    });
   }
 
   /**

--- a/src/common/view/ElementRegistry.ts
+++ b/src/common/view/ElementRegistry.ts
@@ -116,6 +116,7 @@ import { BeamSplitterView } from "./mirrors/BeamSplitterView.js";
 import { IdealCurvedMirrorView } from "./mirrors/IdealCurvedMirrorView.js";
 import { ParabolicMirrorView } from "./mirrors/ParabolicMirrorView.js";
 import { SegmentMirrorView } from "./mirrors/SegmentMirrorView.js";
+import type { ViewOptionsModel } from "./ViewOptionsModel.js";
 
 /** The view type: a Node that also exposes its body-drag listener. */
 export type OpticalElementView = Node & { readonly bodyDragListener: RichDragListener };
@@ -139,6 +140,7 @@ interface ElementDescriptor {
     element: OpticalElement,
     modelViewTransform: ModelViewTransform2,
     tandem: Tandem,
+    viewOptions: ViewOptionsModel,
   ) => OpticalElementView | null;
   /**
    * Build the edit-panel controls for this element type.
@@ -171,8 +173,8 @@ export const ELEMENT_REGISTRY: ElementDescriptor[] = (() => {
     {
       typeKey: "ArcSource",
       label: c.arcSourceStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new ArcLightSourceView(element as ArcLightSource, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new ArcLightSourceView(element as ArcLightSource, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildArcLightSourceControls(element as ArcLightSource, rebuild),
     },
     {
@@ -185,29 +187,29 @@ export const ELEMENT_REGISTRY: ElementDescriptor[] = (() => {
     {
       typeKey: "Beam",
       label: c.beamSourceStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new BeamSourceView(element as BeamSource, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new BeamSourceView(element as BeamSource, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildBeamSourceControls(element as BeamSource, rebuild),
     },
     {
       typeKey: "DivergentBeam",
       label: c.divergentBeamSourceStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new DivergentBeamView(element as DivergentBeam, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new DivergentBeamView(element as DivergentBeam, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildDivergentBeamControls(element as DivergentBeam, rebuild),
     },
     {
       typeKey: "SingleRay",
       label: c.singleRayStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new SingleRaySourceView(element as SingleRaySource, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new SingleRaySourceView(element as SingleRaySource, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildSingleRaySourceControls(element as SingleRaySource, rebuild),
     },
     {
       typeKey: "ContinuousSpectrumSource",
       label: c.continuousSpectrumStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new ContinuousSpectrumSourceView(element as ContinuousSpectrumSource, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new ContinuousSpectrumSourceView(element as ContinuousSpectrumSource, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) =>
         buildContinuousSpectrumSourceControls(element as ContinuousSpectrumSource, rebuild),
     },
@@ -216,45 +218,45 @@ export const ELEMENT_REGISTRY: ElementDescriptor[] = (() => {
     {
       typeKey: "AperturedParabolicMirror",
       label: c.aperturedMirrorStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new AperturedParabolicMirrorView(element as AperturedParabolicMirror, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new AperturedParabolicMirrorView(element as AperturedParabolicMirror, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) =>
         buildAperturedMirrorControls(element as AperturedParabolicMirror, rebuild),
     },
     {
       typeKey: "Mirror",
       label: c.flatMirrorStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new SegmentMirrorView(element as SegmentMirror, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new SegmentMirrorView(element as SegmentMirror, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildSegmentControls(element as SegmentMirror, rebuild),
     },
     {
       typeKey: "ArcMirror",
       label: c.arcMirrorStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new ArcMirrorView(element as ArcMirror, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new ArcMirrorView(element as ArcMirror, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild, { useCurvatureDisplay }) =>
         buildArcMirrorControls(element as ArcMirror, rebuild, useCurvatureDisplay),
     },
     {
       typeKey: "ParabolicMirror",
       label: c.parabolicMirrorStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new ParabolicMirrorView(element as ParabolicMirror, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new ParabolicMirrorView(element as ParabolicMirror, modelViewTransform, tandem, viewOptions),
       // No editable properties for ParabolicMirror.
     },
     {
       typeKey: "IdealMirror",
       label: c.idealMirrorStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new IdealCurvedMirrorView(element as IdealCurvedMirror, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new IdealCurvedMirrorView(element as IdealCurvedMirror, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildIdealCurvedMirrorControls(element as IdealCurvedMirror, rebuild),
     },
     {
       typeKey: "BeamSplitter",
       label: c.beamSplitterStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new BeamSplitterView(element as BeamSplitterElement, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new BeamSplitterView(element as BeamSplitterElement, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildBeamSplitterControls(element as BeamSplitterElement, rebuild),
     },
 
@@ -262,54 +264,54 @@ export const ELEMENT_REGISTRY: ElementDescriptor[] = (() => {
     {
       typeKey: "IdealLens",
       label: c.idealLensStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new IdealLensView(element as IdealLens, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new IdealLensView(element as IdealLens, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildIdealLensControls(element as IdealLens, rebuild),
     },
     {
       typeKey: "CircleGlass",
       label: c.circleGlassStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new CircleGlassView(element as CircleGlass, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new CircleGlassView(element as CircleGlass, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildRefractiveIndexControls(element as CircleGlass, rebuild),
     },
     {
       typeKey: "BiconvexLens",
       label: c.biconvexLensStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new SymmetricLensView(element as BiconvexLens, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new SymmetricLensView(element as BiconvexLens, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild, { signConvention, useCurvatureDisplay }) =>
         buildSymmetricLensControls(element as BiconvexLens, rebuild, signConvention, useCurvatureDisplay),
     },
     {
       typeKey: "BiconcaveLens",
       label: c.biconcaveLensStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new SymmetricLensView(element as BiconcaveLens, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new SymmetricLensView(element as BiconcaveLens, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild, { signConvention, useCurvatureDisplay }) =>
         buildSymmetricLensControls(element as BiconcaveLens, rebuild, signConvention, useCurvatureDisplay),
     },
     {
       typeKey: "PlanoConvexLens",
       label: c.planoConvexLensStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new PlanoLensView(element as PlanoConvexLens, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new PlanoLensView(element as PlanoConvexLens, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild, { signConvention, useCurvatureDisplay }) =>
         buildPlanoLensControls(element as PlanoConvexLens, rebuild, signConvention, useCurvatureDisplay),
     },
     {
       typeKey: "PlanoConcaveLens",
       label: c.planoConcaveLensStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new PlanoLensView(element as PlanoConcaveLens, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new PlanoLensView(element as PlanoConcaveLens, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild, { signConvention, useCurvatureDisplay }) =>
         buildPlanoLensControls(element as PlanoConcaveLens, rebuild, signConvention, useCurvatureDisplay),
     },
     {
       typeKey: "SphericalLens",
       label: c.sphericalLensStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new SphericalLensView(element as SphericalLens, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new SphericalLensView(element as SphericalLens, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild, { signConvention, useCurvatureDisplay }) =>
         buildSphericalLensControls(element as SphericalLens, rebuild, signConvention, useCurvatureDisplay),
     },
@@ -317,56 +319,57 @@ export const ELEMENT_REGISTRY: ElementDescriptor[] = (() => {
     {
       typeKey: "EquilateralPrism",
       label: c.equilateralPrismStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new TypedPrismView(element as EquilateralPrism, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new TypedPrismView(element as EquilateralPrism, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildEquilateralPrismControls(element as EquilateralPrism, rebuild),
     },
     {
       typeKey: "RightAnglePrism",
       label: c.rightAnglePrismStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new TypedPrismView(element as RightAnglePrism, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new TypedPrismView(element as RightAnglePrism, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildRightAnglePrismControls(element as RightAnglePrism, rebuild),
     },
     {
       typeKey: "PorroPrism",
       label: c.porroPrismStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new TypedPrismView(element as PorroPrism, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new TypedPrismView(element as PorroPrism, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildPorroPrismControls(element as PorroPrism, rebuild),
     },
     {
       typeKey: "SlabGlass",
       label: c.slabGlassStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new TypedPrismView(element as SlabGlass, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new TypedPrismView(element as SlabGlass, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildSlabGlassControls(element as SlabGlass, rebuild),
     },
     {
       typeKey: "ParallelogramPrism",
       label: c.parallelogramPrismStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new TypedPrismView(element as ParallelogramPrism, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new TypedPrismView(element as ParallelogramPrism, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildParallelogramPrismControls(element as ParallelogramPrism, rebuild),
     },
     {
       typeKey: "DovePrism",
       label: c.dovePrismStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new TypedPrismView(element as DovePrism, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new TypedPrismView(element as DovePrism, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildDovePrismControls(element as DovePrism, rebuild),
     },
     {
       typeKey: "Glass",
       label: c.glassPrismStringProperty,
-      createView: (element, modelViewTransform, tandem) => new GlassView(element as Glass, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new GlassView(element as Glass, modelViewTransform, tandem, undefined, viewOptions?.handlesVisibleProperty),
       buildEditControls: (element, rebuild) => buildRefractiveIndexControls(element as BaseGlass, rebuild),
     },
     {
       typeKey: "PlaneGlass",
       label: c.halfPlaneGlassStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new HalfPlaneGlassView(element as HalfPlaneGlass, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new HalfPlaneGlassView(element as HalfPlaneGlass, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildHalfPlaneGlassControls(element as HalfPlaneGlass, rebuild),
     },
 
@@ -374,15 +377,15 @@ export const ELEMENT_REGISTRY: ElementDescriptor[] = (() => {
     {
       typeKey: "TransmissionGrating",
       label: c.transmissionGratingStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new TransmissionGratingView(element as TransmissionGrating, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new TransmissionGratingView(element as TransmissionGrating, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildGratingControls(element as TransmissionGrating, rebuild),
     },
     {
       typeKey: "ReflectionGrating",
       label: c.reflectionGratingStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new ReflectionGratingView(element as ReflectionGrating, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new ReflectionGratingView(element as ReflectionGrating, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildGratingControls(element as ReflectionGrating, rebuild),
     },
 
@@ -390,8 +393,8 @@ export const ELEMENT_REGISTRY: ElementDescriptor[] = (() => {
     {
       typeKey: "Detector",
       label: c.detectorStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new DetectorView(element as DetectorElement, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new DetectorView(element as DetectorElement, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild, { useCurvatureDisplay }) =>
         buildDetectorControls(element as DetectorElement, rebuild, useCurvatureDisplay),
     },
@@ -400,15 +403,15 @@ export const ELEMENT_REGISTRY: ElementDescriptor[] = (() => {
     {
       typeKey: "Aperture",
       label: c.apertureStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new ApertureView(element as ApertureElement, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new ApertureView(element as ApertureElement, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildApertureControls(element as ApertureElement, rebuild),
     },
     {
       typeKey: "Blocker",
       label: c.lineBlockerStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new LineBlockerView(element as LineBlocker, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new LineBlockerView(element as LineBlocker, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildSegmentControls(element as LineBlocker, rebuild),
     },
 
@@ -416,8 +419,8 @@ export const ELEMENT_REGISTRY: ElementDescriptor[] = (() => {
     {
       typeKey: "FiberOptic",
       label: c.fiberOpticStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new FiberOpticView(element as FiberOpticElement, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new FiberOpticView(element as FiberOpticElement, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildFiberOpticControls(element as FiberOpticElement, rebuild),
     },
 
@@ -425,8 +428,8 @@ export const ELEMENT_REGISTRY: ElementDescriptor[] = (() => {
     {
       typeKey: "Track",
       label: c.trackStringProperty,
-      createView: (element, modelViewTransform, tandem) =>
-        new TrackView(element as TrackElement, modelViewTransform, tandem),
+      createView: (element, modelViewTransform, tandem, viewOptions) =>
+        new TrackView(element as TrackElement, modelViewTransform, tandem, viewOptions),
       buildEditControls: (element, rebuild) => buildSegmentControls(element as TrackElement, rebuild),
     },
   ];
@@ -449,9 +452,10 @@ export function createOpticalElementView(
   element: OpticalElement,
   modelViewTransform: ModelViewTransform2,
   tandem: Tandem,
+  viewOptions: ViewOptionsModel,
 ): OpticalElementView | null {
   const descriptor = RegistryMap.get(element.type);
-  return descriptor ? descriptor.createView(element, modelViewTransform, tandem) : null;
+  return descriptor ? descriptor.createView(element, modelViewTransform, tandem, viewOptions) : null;
 }
 
 /**

--- a/src/common/view/OpticalElementViewFactory.ts
+++ b/src/common/view/OpticalElementViewFactory.ts
@@ -12,6 +12,7 @@ import opticsLab from "../../OpticsLabNamespace.js";
 import type { OpticalElement } from "../model/optics/OpticsTypes.js";
 import type { OpticalElementView } from "./ElementRegistry.js";
 import { createOpticalElementView as createFromRegistry } from "./ElementRegistry.js";
+import type { ViewOptionsModel } from "./ViewOptionsModel.js";
 
 // Re-export so callers that previously imported OpticalElementView from this
 // file continue to work without any import-path changes.
@@ -25,8 +26,9 @@ export function createOpticalElementView(
   element: OpticalElement,
   modelViewTransform: ModelViewTransform2,
   tandem: Tandem,
+  viewOptions: ViewOptionsModel,
 ): OpticalElementView | null {
-  return createFromRegistry(element, modelViewTransform, tandem);
+  return createFromRegistry(element, modelViewTransform, tandem, viewOptions);
 }
 
 opticsLab.register("createOpticalElementView", createOpticalElementView);

--- a/src/common/view/RayPropagationView.ts
+++ b/src/common/view/RayPropagationView.ts
@@ -34,8 +34,7 @@ import {
 import opticsLab from "../../OpticsLabNamespace.js";
 import type { ViewMode } from "../model/optics/OpticsTypes.js";
 import type { TracedSegment } from "../model/optics/RayTracer.js";
-import { rayArrowsVisibleProperty } from "./RayArrowsVisibleProperty.js";
-import { rayStubLengthPxProperty, rayStubsEnabledProperty } from "./RayStubsProperty.js";
+import type { ViewOptionsModel } from "./ViewOptionsModel.js";
 
 // Cohen–Sutherland region codes
 const CS_INSIDE = 0;
@@ -122,17 +121,24 @@ export class RayPropagationView extends CanvasNode {
   private segments: TracedSegment[] = [];
   private mode: ViewMode = "rays";
   private readonly modelViewTransform: ModelViewTransform2;
+  private readonly viewOptions: ViewOptionsModel;
 
-  public constructor(canvasBounds: Bounds2, modelViewTransform: ModelViewTransform2, options?: CanvasNodeOptions) {
+  public constructor(
+    canvasBounds: Bounds2,
+    modelViewTransform: ModelViewTransform2,
+    viewOptions: ViewOptionsModel,
+    options?: CanvasNodeOptions,
+  ) {
     super({
       canvasBounds,
       pickable: false, // rays are non-interactive
       ...options,
     });
     this.modelViewTransform = modelViewTransform;
-    rayArrowsVisibleProperty.lazyLink(() => this.invalidatePaint());
-    rayStubsEnabledProperty.lazyLink(() => this.invalidatePaint());
-    rayStubLengthPxProperty.lazyLink(() => this.invalidatePaint());
+    this.viewOptions = viewOptions;
+    viewOptions.rayArrowsVisibleProperty.lazyLink(() => this.invalidatePaint());
+    viewOptions.rayStubsEnabledProperty.lazyLink(() => this.invalidatePaint());
+    viewOptions.rayStubLengthPxProperty.lazyLink(() => this.invalidatePaint());
   }
 
   /**
@@ -176,7 +182,7 @@ export class RayPropagationView extends CanvasNode {
     } else {
       this.paintExtensionRays(context, segments, clipRect);
       this.paintForwardRays(context, segments, clipRect);
-      if (rayArrowsVisibleProperty.value && !rayStubsEnabledProperty.value) {
+      if (this.viewOptions.rayArrowsVisibleProperty.value && !this.viewOptions.rayStubsEnabledProperty.value) {
         this.paintArrowheads(context, segments, clipRect);
       }
     }
@@ -184,7 +190,7 @@ export class RayPropagationView extends CanvasNode {
 
   private paintExtensionRays(context: CanvasRenderingContext2D, segments: TracedSegment[], clipRect: ClipRect): void {
     // When ray stubs are enabled, suppress extension rays entirely.
-    if (rayStubsEnabledProperty.value) {
+    if (this.viewOptions.rayStubsEnabledProperty.value) {
       return;
     }
     const modelViewTransform = this.modelViewTransform;
@@ -241,8 +247,8 @@ export class RayPropagationView extends CanvasNode {
     const modelViewTransform = this.modelViewTransform;
     context.lineWidth = RAY_LINE_WIDTH;
 
-    const stubsEnabled = rayStubsEnabledProperty.value;
-    const stubLengthPx = rayStubLengthPxProperty.value;
+    const stubsEnabled = this.viewOptions.rayStubsEnabledProperty.value;
+    const stubLengthPx = this.viewOptions.rayStubLengthPxProperty.value;
 
     const paintSegment = (seg: TracedSegment, additive: boolean): void => {
       // In stub mode, only draw segments emitted directly from a light source.

--- a/src/common/view/RayPropagationView.ts
+++ b/src/common/view/RayPropagationView.ts
@@ -122,6 +122,8 @@ export class RayPropagationView extends CanvasNode {
   private mode: ViewMode = "rays";
   private readonly modelViewTransform: ModelViewTransform2;
   private readonly viewOptions: ViewOptionsModel;
+  /** Shared listener stored so it can be unlinked in dispose(). */
+  private readonly _invalidatePaintListener = () => this.invalidatePaint();
 
   public constructor(
     canvasBounds: Bounds2,
@@ -136,9 +138,16 @@ export class RayPropagationView extends CanvasNode {
     });
     this.modelViewTransform = modelViewTransform;
     this.viewOptions = viewOptions;
-    viewOptions.rayArrowsVisibleProperty.lazyLink(() => this.invalidatePaint());
-    viewOptions.rayStubsEnabledProperty.lazyLink(() => this.invalidatePaint());
-    viewOptions.rayStubLengthPxProperty.lazyLink(() => this.invalidatePaint());
+    viewOptions.rayArrowsVisibleProperty.lazyLink(this._invalidatePaintListener);
+    viewOptions.rayStubsEnabledProperty.lazyLink(this._invalidatePaintListener);
+    viewOptions.rayStubLengthPxProperty.lazyLink(this._invalidatePaintListener);
+  }
+
+  public override dispose(): void {
+    this.viewOptions.rayArrowsVisibleProperty.unlink(this._invalidatePaintListener);
+    this.viewOptions.rayStubsEnabledProperty.unlink(this._invalidatePaintListener);
+    this.viewOptions.rayStubLengthPxProperty.unlink(this._invalidatePaintListener);
+    super.dispose();
   }
 
   /**

--- a/src/common/view/SceneSVGExporter.ts
+++ b/src/common/view/SceneSVGExporter.ts
@@ -25,8 +25,8 @@ import {
 } from "../../OpticsLabConstants.js";
 import type { OpticalElement } from "../model/optics/OpticsTypes.js";
 import type { TracedSegment } from "../model/optics/RayTracer.js";
-import { handlesVisibleProperty } from "./HandlesVisibleProperty.js";
 import { createOpticalElementView, type OpticalElementView } from "./OpticalElementViewFactory.js";
+import { ViewOptionsModel } from "./ViewOptionsModel.js";
 
 /**
  * Scenery may introduce Canvas layers (full-size, cleared opaque) above SVG layers when the subtree mixes
@@ -291,8 +291,8 @@ export function downloadSceneSVG({
   segments,
   viewState,
 }: SceneSVGExportOptions): void {
-  const savedHandlesVisible = handlesVisibleProperty.value;
-  handlesVisibleProperty.value = viewState.showHandles;
+  const exportViewOptions = new ViewOptionsModel();
+  exportViewOptions.handlesVisibleProperty.value = viewState.showHandles;
 
   const exportWidth = Math.ceil(visibleBounds.width);
   const exportHeight = Math.ceil(visibleBounds.height);
@@ -340,7 +340,7 @@ export function downloadSceneSVG({
 
     const elementsLayer = new Node();
     for (const element of elements) {
-      const view = createOpticalElementView(element, exportMVT, Tandem.OPT_OUT);
+      const view = createOpticalElementView(element, exportMVT, Tandem.OPT_OUT, exportViewOptions);
       if (!view) {
         continue;
       }
@@ -419,7 +419,6 @@ export function downloadSceneSVG({
       display.dispose();
     }
   } finally {
-    handlesVisibleProperty.value = savedHandlesVisible;
     for (const overlayNode of exportOverlayNodes) {
       overlayNode.dispose();
     }

--- a/src/common/view/SimScreenView.ts
+++ b/src/common/view/SimScreenView.ts
@@ -21,18 +21,15 @@ import { CarouselPanel } from "./CarouselPanel.js";
 import type { ComponentKey } from "./ComponentCarousel.js";
 import { DetectorView } from "./detectors/DetectorView.js";
 import { EditContainerNode } from "./EditContainerNode.js";
-import { focalMarkersVisibleProperty } from "./FocalMarkersVisibleProperty.js";
-import { handlesVisibleProperty } from "./HandlesVisibleProperty.js";
 import { ImageOverlayNode } from "./ImageOverlayNode.js";
 import { InfoDialogNode } from "./InfoDialogNode.js";
 import { ObserverNode } from "./ObserverNode.js";
 import { createOpticalElementView, type OpticalElementView } from "./OpticalElementViewFactory.js";
-import { rayArrowsVisibleProperty } from "./RayArrowsVisibleProperty.js";
 import { RayPropagationView } from "./RayPropagationView.js";
-import { rayStubsEnabledProperty } from "./RayStubsProperty.js";
 import { sceneHistoryRegistry } from "./SceneHistoryRegistry.js";
 import { downloadSceneSVG } from "./SceneSVGExporter.js";
 import { ToolsPanel } from "./ToolsPanel.js";
+import { ViewOptionsModel } from "./ViewOptionsModel.js";
 import { viewSnapState } from "./ViewSnapState.js";
 
 /**
@@ -83,6 +80,10 @@ function tryHandleToolsPanelShortcut(
     extendedRaysProperty: BooleanProperty;
     gridVisibleProperty: BooleanProperty;
     snapToGridProperty: BooleanProperty;
+    handlesVisibleProperty: BooleanProperty;
+    focalMarkersVisibleProperty: BooleanProperty;
+    rayArrowsVisibleProperty: BooleanProperty;
+    rayStubsEnabledProperty: BooleanProperty;
   },
 ): boolean {
   if (isTextInput || event.ctrlKey || event.metaKey || event.altKey || event.key.length !== 1) {
@@ -95,6 +96,10 @@ function tryHandleToolsPanelShortcut(
     extendedRaysProperty,
     gridVisibleProperty,
     snapToGridProperty,
+    handlesVisibleProperty,
+    focalMarkersVisibleProperty,
+    rayArrowsVisibleProperty,
+    rayStubsEnabledProperty,
   } = locals;
   if (letter === "m") {
     measuringTapeVisibleProperty.toggle();
@@ -178,6 +183,9 @@ export class RayTracingCommonView extends ScreenView {
   /** Maps element id → view so we can remove views and provide rebuild callbacks. */
   private readonly elementViewMap = new Map<string, OpticalElementView>();
 
+  /** Per-screen view state (handles visibility, ray arrows, focal markers, etc.). */
+  protected readonly viewOptions: ViewOptionsModel;
+
   /**
    * Maps element id → its Tandem so we can remove it from the global tandem tree on deletion.
    * RichDragListener is not a PhetioObject, so its tandem's dispose() is never triggered
@@ -229,6 +237,8 @@ export class RayTracingCommonView extends ScreenView {
     sceneHistoryRegistry.setHistory(model.scene.history);
     const tandem = options?.tandem;
     const uiStrings = StringManager.getInstance().getUIStrings();
+
+    this.viewOptions = new ViewOptionsModel(tandem?.createTandem("viewOptions"));
 
     // ── Model-View Transform ────────────────────────────────────────────────
     // Maps model origin (0, 0) to the centre of the visible play area.
@@ -316,7 +326,11 @@ export class RayTracingCommonView extends ScreenView {
     viewSnapState.setSnapToGrid(snapToGridProperty);
 
     // ── Ray Propagation Layer (behind elements so rays don't block handles) ─
-    this.rayPropagationView = new RayPropagationView(this.visibleBoundsProperty.value, modelViewTransform);
+    this.rayPropagationView = new RayPropagationView(
+      this.visibleBoundsProperty.value,
+      modelViewTransform,
+      this.viewOptions,
+    );
     this.visibleBoundsProperty.link((visibleBounds) => {
       this.rayPropagationView.canvasBounds = visibleBounds;
     });
@@ -398,7 +412,7 @@ export class RayTracingCommonView extends ScreenView {
         // view already exists and skips duplicate creation.
         const tandemName = element.id.replace(/-(\d+)$/, (_, n) => n);
         const elementTandem = tandem?.createTandem(tandemName) ?? Tandem.OPTIONAL;
-        const view = createOpticalElementView(element, modelViewTransform, elementTandem);
+        const view = createOpticalElementView(element, modelViewTransform, elementTandem, this.viewOptions);
         if (view) {
           this.elementTandemMap.set(element.id, elementTandem);
           this._setupView(element, view);
@@ -435,7 +449,7 @@ export class RayTracingCommonView extends ScreenView {
     for (const element of model.scene.getAllElements()) {
       const tandemName = element.id.replace(/-(\d+)$/, (_, n) => n);
       const elementTandem = tandem?.createTandem(tandemName) ?? Tandem.OPTIONAL;
-      const elementView = createOpticalElementView(element, modelViewTransform, elementTandem);
+      const elementView = createOpticalElementView(element, modelViewTransform, elementTandem, this.viewOptions);
       if (elementView) {
         this.elementTandemMap.set(element.id, elementTandem);
         this._setupView(element, elementView);
@@ -452,7 +466,7 @@ export class RayTracingCommonView extends ScreenView {
       }
       const tn = element.id.replace(/-(\d+)$/, (_, n: string) => n);
       const et = tandem?.createTandem(tn) ?? Tandem.OPTIONAL;
-      const view = createOpticalElementView(element, modelViewTransform, et);
+      const view = createOpticalElementView(element, modelViewTransform, et, this.viewOptions);
       if (view) {
         this.elementTandemMap.set(element.id, et);
         this._setupView(element, view);
@@ -492,6 +506,7 @@ export class RayTracingCommonView extends ScreenView {
       this.selectedElementProperty,
       this.visibleBoundsProperty,
       _opticsLabPreferences.snapToGridProperty,
+      this.viewOptions,
       tandem,
     );
     this.addChild(toolsPanel);
@@ -526,7 +541,7 @@ export class RayTracingCommonView extends ScreenView {
           viewState: {
             showGrid: model.scene.showGridProperty.value,
             gridSpacing: model.scene.gridSizeProperty.value,
-            showHandles: handlesVisibleProperty.value,
+            showHandles: this.viewOptions.handlesVisibleProperty.value,
             measuringTape: {
               visible: toolsPanel.measuringTapeVisibleProperty.value,
               basePosition: toolsPanel.measuringTapeNode.basePositionProperty.value.copy(),
@@ -618,6 +633,10 @@ export class RayTracingCommonView extends ScreenView {
           extendedRaysProperty: toolsPanel.extendedRaysProperty,
           gridVisibleProperty: model.scene.showGridProperty,
           snapToGridProperty: _opticsLabPreferences.snapToGridProperty,
+          handlesVisibleProperty: this.viewOptions.handlesVisibleProperty,
+          focalMarkersVisibleProperty: this.viewOptions.focalMarkersVisibleProperty,
+          rayArrowsVisibleProperty: this.viewOptions.rayArrowsVisibleProperty,
+          rayStubsEnabledProperty: this.viewOptions.rayStubsEnabledProperty,
         })
       ) {
         event.preventDefault();

--- a/src/common/view/SimScreenView.ts
+++ b/src/common/view/SimScreenView.ts
@@ -686,6 +686,7 @@ export class RayTracingCommonView extends ScreenView {
   public override dispose(): void {
     window.removeEventListener("keydown", this._handleKeyDown);
     super.dispose();
+    this.viewOptions.dispose();
   }
 
   public override step(_dt: number): void {

--- a/src/common/view/ToolsPanel.ts
+++ b/src/common/view/ToolsPanel.ts
@@ -58,11 +58,7 @@ import {
 import opticsLabQueryParameters from "../../preferences/opticsLabQueryParameters.js";
 import type { OpticalElement } from "../model/optics/OpticsTypes.js";
 import type { RayTracingCommonModel } from "../model/SimModel.js";
-import { focalMarkersVisibleProperty } from "./FocalMarkersVisibleProperty.js";
-import { handlesVisibleProperty } from "./HandlesVisibleProperty.js";
 import { DEFAULT_OBSERVER } from "./ObserverNode.js";
-import { rayArrowsVisibleProperty } from "./RayArrowsVisibleProperty.js";
-import { rayStubsEnabledProperty } from "./RayStubsProperty.js";
 import {
   dragHandleIcon,
   extendedRaysIcon,
@@ -77,6 +73,7 @@ import {
   showImagesIcon,
   snapToGridIcon,
 } from "./ToolsPanelIcons.js";
+import type { ViewOptionsModel } from "./ViewOptionsModel.js";
 
 export class ToolsPanel extends Node {
   /** Draggable measuring-tape overlay – add to scene in the desired z-order. */
@@ -91,6 +88,8 @@ export class ToolsPanel extends Node {
   public readonly measuringTapeVisibleProperty: BooleanProperty;
   public readonly protractorVisibleProperty: BooleanProperty;
 
+  private readonly viewOptions: ViewOptionsModel;
+
   /**
    * Whether "Extended Rays" mode is active.  Changing this property updates
    * model.scene.modeProperty; conversely, external modeProperty changes update
@@ -104,9 +103,11 @@ export class ToolsPanel extends Node {
     selectedElementProperty: Property<OpticalElement | null>,
     visibleBoundsProperty: ReadOnlyProperty<Bounds2>,
     snapToGridProperty: Property<boolean>,
+    viewOptions: ViewOptionsModel,
     tandem: Tandem | undefined,
   ) {
     super();
+    this.viewOptions = viewOptions;
 
     const strings = StringManager.getInstance();
     const uiStrings = strings.getUIStrings();
@@ -274,22 +275,22 @@ export class ToolsPanel extends Node {
         { ...checkboxOptions, ...cbTandem("observerModeCheckbox") },
       ),
       new Checkbox(
-        handlesVisibleProperty,
+        viewOptions.handlesVisibleProperty,
         makeCheckboxContent(dragHandleIcon(), uiStrings.showHandlesStringProperty, labelOptions),
         { ...checkboxOptions, ...cbTandem("showHandlesCheckbox") },
       ),
       new Checkbox(
-        focalMarkersVisibleProperty,
+        viewOptions.focalMarkersVisibleProperty,
         makeCheckboxContent(focalPointIcon(), uiStrings.focalMarkersStringProperty, labelOptions),
         { ...checkboxOptions, ...cbTandem("focalMarkersCheckbox") },
       ),
       new Checkbox(
-        rayArrowsVisibleProperty,
+        viewOptions.rayArrowsVisibleProperty,
         makeCheckboxContent(rayArrowsIcon(), uiStrings.showRayArrowsStringProperty, labelOptions),
         { ...checkboxOptions, ...cbTandem("rayArrowsCheckbox") },
       ),
       new Checkbox(
-        rayStubsEnabledProperty,
+        viewOptions.rayStubsEnabledProperty,
         makeCheckboxContent(rayStubsIcon(), uiStrings.rayStubsStringProperty, labelOptions),
         { ...checkboxOptions, ...cbTandem("rayStubsCheckbox") },
       ),
@@ -343,10 +344,7 @@ export class ToolsPanel extends Node {
     this.extendedRaysProperty.reset();
     this.measuringTapeVisibleProperty.reset();
     this.protractorVisibleProperty.reset();
-    handlesVisibleProperty.reset();
-    focalMarkersVisibleProperty.reset();
-    rayArrowsVisibleProperty.reset();
-    rayStubsEnabledProperty.reset();
+    this.viewOptions.reset();
     this.measuringTapeNode.basePositionProperty.reset();
     this.measuringTapeNode.tipPositionProperty.reset();
     this.protractorNode.angleProperty.reset();

--- a/src/common/view/ViewHelpers.ts
+++ b/src/common/view/ViewHelpers.ts
@@ -16,6 +16,7 @@
  * that `listener.modelDelta` is already in model units.
  */
 
+import type { TReadOnlyProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Circle, InteractiveHighlighting, type Node, Path, RichDragListener } from "scenerystack/scenery";
@@ -39,7 +40,6 @@ import {
   segment,
   subtract,
 } from "../model/optics/Geometry.js";
-import { handlesVisibleProperty } from "./HandlesVisibleProperty.js";
 import { sceneHistoryRegistry } from "./SceneHistoryRegistry.js";
 import { trackRegistry } from "./TrackRegistry.js";
 import { viewSnapState } from "./ViewSnapState.js";
@@ -80,13 +80,13 @@ function snapPoint(p: Point): Point {
 // ── Handle appearance ─────────────────────────────────────────────────────────
 
 /**
- * Tracks handlesVisibleProperty.linkAttribute handles per Circle node so they
- * can be unlinked when the owning view is disposed.
+ * Tracks the unlink function for handles' visibility linkAttribute, keyed by
+ * the Circle node.  Called from BaseOpticalElementView.dispose() for cleanup.
  */
 const handleVisibilityUnlinks = new WeakMap<Node, () => void>();
 
 /**
- * Unlink the handlesVisibleProperty linkAttribute for a given handle node.
+ * Unlink the visibility linkAttribute for a given handle node.
  * Call from BaseOpticalElementView.dispose() for each child handle.
  */
 export function unlinkHandleVisibility(node: Node): void {
@@ -108,9 +108,14 @@ export type DragHandle = Circle & { syncToModel(): void };
 
 /**
  * Creates a small control-point circle at the view position corresponding to
- * the given model point.
+ * the given model point.  Visibility is bound to `handlesVisibleProperty` so
+ * the handle disappears when handles are hidden.
  */
-export function createHandle(p: Point, modelViewTransform: ModelViewTransform2): Circle {
+export function createHandle(
+  p: Point,
+  modelViewTransform: ModelViewTransform2,
+  handlesVisibleProperty: TReadOnlyProperty<boolean>,
+): Circle {
   const handle = new (InteractiveHighlighting(Circle))(HANDLE_RADIUS, {
     x: modelViewTransform.modelToViewX(p.x),
     y: modelViewTransform.modelToViewY(p.y),
@@ -123,8 +128,11 @@ export function createHandle(p: Point, modelViewTransform: ModelViewTransform2):
     accessibleName: "Drag handle",
     accessibleHelpText: "Press arrow keys to adjust",
   });
-  const unlinkHandle = handlesVisibleProperty.linkAttribute(handle, "visible");
-  handleVisibilityUnlinks.set(handle, () => handlesVisibleProperty.unlink(unlinkHandle));
+  const visibilityListener = (visible: boolean) => {
+    handle.visible = visible;
+  };
+  handlesVisibleProperty.link(visibilityListener);
+  handleVisibilityUnlinks.set(handle, () => handlesVisibleProperty.unlink(visibilityListener));
   return handle;
 }
 
@@ -143,8 +151,9 @@ export function makeEndpointHandle(
   rebuild: () => void,
   modelViewTransform: ModelViewTransform2,
   tandem: Tandem,
+  handlesVisibleProperty: TReadOnlyProperty<boolean>,
 ): DragHandle {
-  const handle = createHandle(getPoint(), modelViewTransform);
+  const handle = createHandle(getPoint(), modelViewTransform, handlesVisibleProperty);
   attachEndpointDrag(handle, getPoint, setPoint, rebuild, modelViewTransform, tandem);
   return Object.assign(handle, {
     syncToModel(): void {

--- a/src/common/view/ViewOptionsModel.ts
+++ b/src/common/view/ViewOptionsModel.ts
@@ -1,0 +1,64 @@
+/**
+ * ViewOptionsModel.ts
+ *
+ * Per-screen view-state model that owns the five view-toggle properties
+ * previously held as module-level singletons.  Instantiating one per screen
+ * lets each screen maintain independent settings and makes the properties
+ * visible to PhET-iO via Tandem instrumentation.
+ *
+ * Properties
+ * ──────────
+ *   handlesVisibleProperty       – show/hide drag-handle circles
+ *   focalMarkersVisibleProperty  – show/hide focal-point marker diamonds
+ *   rayArrowsVisibleProperty     – show/hide directional arrowheads on rays
+ *   rayStubsEnabledProperty      – toggle "ray stubs" display mode
+ *   rayStubLengthPxProperty      – stub length in view pixels
+ */
+
+import { BooleanProperty, NumberProperty } from "scenerystack/axon";
+import { Range } from "scenerystack/dot";
+import type { Tandem } from "scenerystack/tandem";
+import { RAY_STUB_LENGTH_MAX_PX, RAY_STUB_LENGTH_MIN_PX } from "../../OpticsLabConstants.js";
+import opticsLab from "../../OpticsLabNamespace.js";
+import opticsLabQueryParameters from "../../preferences/opticsLabQueryParameters.js";
+
+export class ViewOptionsModel {
+  public readonly handlesVisibleProperty: BooleanProperty;
+  public readonly focalMarkersVisibleProperty: BooleanProperty;
+  public readonly rayArrowsVisibleProperty: BooleanProperty;
+  public readonly rayStubsEnabledProperty: BooleanProperty;
+  public readonly rayStubLengthPxProperty: NumberProperty;
+
+  public constructor(tandem?: Tandem) {
+    this.handlesVisibleProperty = new BooleanProperty(opticsLabQueryParameters.showHandles, {
+      ...(tandem && { tandem: tandem.createTandem("handlesVisibleProperty") }),
+    });
+
+    this.focalMarkersVisibleProperty = new BooleanProperty(opticsLabQueryParameters.showFocalMarkers, {
+      ...(tandem && { tandem: tandem.createTandem("focalMarkersVisibleProperty") }),
+    });
+
+    this.rayArrowsVisibleProperty = new BooleanProperty(opticsLabQueryParameters.showRayArrows, {
+      ...(tandem && { tandem: tandem.createTandem("rayArrowsVisibleProperty") }),
+    });
+
+    this.rayStubsEnabledProperty = new BooleanProperty(opticsLabQueryParameters.showRayStubs, {
+      ...(tandem && { tandem: tandem.createTandem("rayStubsEnabledProperty") }),
+    });
+
+    this.rayStubLengthPxProperty = new NumberProperty(opticsLabQueryParameters.rayStubLength, {
+      range: new Range(RAY_STUB_LENGTH_MIN_PX, RAY_STUB_LENGTH_MAX_PX),
+      ...(tandem && { tandem: tandem.createTandem("rayStubLengthPxProperty") }),
+    });
+  }
+
+  public reset(): void {
+    this.handlesVisibleProperty.reset();
+    this.focalMarkersVisibleProperty.reset();
+    this.rayArrowsVisibleProperty.reset();
+    this.rayStubsEnabledProperty.reset();
+    this.rayStubLengthPxProperty.reset();
+  }
+}
+
+opticsLab.register("ViewOptionsModel", ViewOptionsModel);

--- a/src/common/view/ViewOptionsModel.ts
+++ b/src/common/view/ViewOptionsModel.ts
@@ -59,6 +59,14 @@ export class ViewOptionsModel {
     this.rayStubsEnabledProperty.reset();
     this.rayStubLengthPxProperty.reset();
   }
+
+  public dispose(): void {
+    this.handlesVisibleProperty.dispose();
+    this.focalMarkersVisibleProperty.dispose();
+    this.rayArrowsVisibleProperty.dispose();
+    this.rayStubsEnabledProperty.dispose();
+    this.rayStubLengthPxProperty.dispose();
+  }
 }
 
 opticsLab.register("ViewOptionsModel", ViewOptionsModel);

--- a/src/common/view/blockers/ApertureView.ts
+++ b/src/common/view/blockers/ApertureView.ts
@@ -5,6 +5,7 @@
  * with a gap between them. Handles at p1, p2, p3, p4 allow reshaping.
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -15,6 +16,7 @@ import opticsLab from "../../../OpticsLabNamespace.js";
 import type { ApertureElement } from "../../model/blockers/ApertureElement.js";
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
 import { attachTranslationDrag, type DragHandle, makeEndpointHandle } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class ApertureView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -27,10 +29,16 @@ export class ApertureView extends BaseOpticalElementView {
 
   private readonly aperture: ApertureElement;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(aperture: ApertureElement, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    aperture: ApertureElement,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.aperture = aperture;
     this.modelViewTransform = modelViewTransform;
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.backPath = new Path(null, {
       stroke: OpticsLabColors.blockerBackStrokeProperty,
@@ -53,6 +61,7 @@ export class ApertureView extends BaseOpticalElementView {
       rebuild,
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => aperture.p2,
@@ -62,6 +71,7 @@ export class ApertureView extends BaseOpticalElementView {
       rebuild,
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      handlesVisibleProperty,
     );
     this.handle3 = makeEndpointHandle(
       () => aperture.p3,
@@ -71,6 +81,7 @@ export class ApertureView extends BaseOpticalElementView {
       rebuild,
       modelViewTransform,
       tandem.createTandem("handle3DragListener"),
+      handlesVisibleProperty,
     );
     this.handle4 = makeEndpointHandle(
       () => aperture.p4,
@@ -80,6 +91,7 @@ export class ApertureView extends BaseOpticalElementView {
       rebuild,
       modelViewTransform,
       tandem.createTandem("handle4DragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.backPath);

--- a/src/common/view/blockers/LineBlockerView.ts
+++ b/src/common/view/blockers/LineBlockerView.ts
@@ -5,6 +5,7 @@
  * Endpoint handles and a body-drag region let the user reshape and reposition.
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -21,6 +22,7 @@ import {
   type DragHandle,
   makeEndpointHandle,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class LineBlockerView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -32,10 +34,16 @@ export class LineBlockerView extends BaseOpticalElementView {
 
   private readonly blocker: LineBlocker;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(blocker: LineBlocker, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    blocker: LineBlocker,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.blocker = blocker;
     this.modelViewTransform = modelViewTransform;
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.backPath = new Path(null, {
       stroke: OpticsLabColors.blockerBackStrokeProperty,
@@ -60,6 +68,7 @@ export class LineBlockerView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => blocker.p2,
@@ -71,6 +80,7 @@ export class LineBlockerView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.backPath);

--- a/src/common/view/detectors/DetectorView.ts
+++ b/src/common/view/detectors/DetectorView.ts
@@ -47,6 +47,7 @@ import {
   makeEndpointHandle,
   projectPointOntoPerpendicularBisector,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 import { DetectorChartPanel } from "./DetectorChartPanel.js";
 
 const INITIAL_CHART_OFFSET_Y = 10;
@@ -74,7 +75,12 @@ export class DetectorView extends BaseOpticalElementView {
 
   private readonly detector: DetectorElement;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(detector: DetectorElement, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    detector: DetectorElement,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions: ViewOptionsModel,
+  ) {
     super();
     this.detector = detector;
     this.modelViewTransform = modelViewTransform;
@@ -116,6 +122,7 @@ export class DetectorView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => detector.p2,
@@ -128,8 +135,9 @@ export class DetectorView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
-    this.handle3 = createHandle(detector.p3, modelViewTransform);
+    this.handle3 = createHandle(detector.p3, modelViewTransform, viewOptions.handlesVisibleProperty);
 
     this.chartPanel = new DetectorChartPanel({ onAcquire: () => detector.startAcquisition() });
     this.chartPanel.cursor = "pointer";

--- a/src/common/view/fiber/FiberOpticView.ts
+++ b/src/common/view/fiber/FiberOpticView.ts
@@ -18,6 +18,7 @@
  * primary bodyDragListener used by the carousel forwarding mechanism.
  */
 
+import { BooleanProperty, type TReadOnlyProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { InteractiveHighlighting, Path, type RichDragListener } from "scenerystack/scenery";
@@ -29,6 +30,7 @@ import type { FiberOpticElement } from "../../model/fiber/FiberOpticElement.js";
 import type { Point } from "../../model/optics/Geometry.js";
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
 import { attachEndpointDrag, attachTranslationDrag, createHandle, type DragHandle } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 // ── Internal geometry helpers ─────────────────────────────────────────────────
 
@@ -117,10 +119,17 @@ export class FiberOpticView extends BaseOpticalElementView {
 
   private readonly fiber: FiberOpticElement;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(fiber: FiberOpticElement, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  private readonly handlesVisibleProperty: TReadOnlyProperty<boolean>;
+  public constructor(
+    fiber: FiberOpticElement,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.fiber = fiber;
     this.modelViewTransform = modelViewTransform;
+    this.handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     // ── Outer cladding (glass physics boundary, visual background layer) ──
     this.claddingPath = new Path(null, {
@@ -254,7 +263,7 @@ export class FiberOpticView extends BaseOpticalElementView {
     rebuild: () => void,
     tandem: Tandem,
   ): DragHandle {
-    const handle = createHandle(getPoint(), this.modelViewTransform) as DragHandle;
+    const handle = createHandle(getPoint(), this.modelViewTransform, this.handlesVisibleProperty) as DragHandle;
     attachEndpointDrag(handle, getPoint, setPoint, rebuild, this.modelViewTransform, tandem);
     Object.assign(handle, {
       syncToModel: () => {

--- a/src/common/view/glass/CircleGlassView.ts
+++ b/src/common/view/glass/CircleGlassView.ts
@@ -6,6 +6,7 @@
  * A center handle translates the whole circle; a boundary handle resizes it.
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -16,6 +17,7 @@ import opticsLab from "../../../OpticsLabNamespace.js";
 import type { CircleGlass } from "../../model/glass/CircleGlass.js";
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
 import { attachTranslationDrag, type DragHandle, makeEndpointHandle } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class CircleGlassView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -25,10 +27,17 @@ export class CircleGlassView extends BaseOpticalElementView {
 
   private readonly glass: CircleGlass;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(glass: CircleGlass, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    glass: CircleGlass,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.glass = glass;
     this.modelViewTransform = modelViewTransform;
+
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.circlePath = new Path(null, {
       fill: glassFill(glass.refIndex),
@@ -48,6 +57,7 @@ export class CircleGlassView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("centerDragListener"),
+      handlesVisibleProperty,
     );
     // Boundary handle: resizes the circle (only p2 moves)
     this.handleBoundary = makeEndpointHandle(
@@ -60,6 +70,7 @@ export class CircleGlassView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("boundaryDragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.circlePath);

--- a/src/common/view/glass/GlassView.ts
+++ b/src/common/view/glass/GlassView.ts
@@ -11,6 +11,7 @@
  * Replaces the former PolygonGlassView (which only handled line segments).
  */
 
+import { BooleanProperty, type TReadOnlyProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Circle, Node, Path, type RichDragListener } from "scenerystack/scenery";
@@ -46,6 +47,8 @@ export class GlassView extends BaseOpticalElementView {
   private readonly isPrism: boolean;
   private readonly handleVertsOption: GlassPathPoint[] | undefined;
   protected readonly glassTandem: Tandem;
+  /** Per-screen property controlling visibility of vertex drag handles. */
+  protected readonly handlesVisibleProperty: TReadOnlyProperty<boolean>;
 
   public get bodyDragListener(): RichDragListener {
     return this._bodyDragListener;
@@ -58,11 +61,15 @@ export class GlassView extends BaseOpticalElementView {
     modelViewTransform: ModelViewTransform2,
     tandem?: Tandem,
     handleVerts?: GlassPathPoint[],
+    handlesVisibleProperty?: TReadOnlyProperty<boolean>,
   ) {
     super();
     this.glass = glass;
     this.modelViewTransform = modelViewTransform;
     this.glassTandem = tandem ?? Tandem.OPT_OUT;
+    // Use the per-screen property when provided; otherwise default to always-visible
+    // so that uninstrumented usages (e.g. the SVG exporter) still render handles.
+    this.handlesVisibleProperty = handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.glassPath = new Path(null, {
       fill: glassFill(glass.refIndex),
@@ -125,6 +132,7 @@ export class GlassView extends BaseOpticalElementView {
         },
         this.modelViewTransform,
         this.glassTandem.createTandem(`vertexDragListener${index}`),
+        this.handlesVisibleProperty,
       );
       if (this.isPrism && this.glass.path.length > 3) {
         const removeBtn = this.createRemoveButton();

--- a/src/common/view/glass/HalfPlaneGlassView.ts
+++ b/src/common/view/glass/HalfPlaneGlassView.ts
@@ -9,6 +9,7 @@
  *    boundary line translates the whole element
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -29,6 +30,7 @@ import {
   type DragHandle,
   makeEndpointHandle,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class HalfPlaneGlassView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -40,10 +42,17 @@ export class HalfPlaneGlassView extends BaseOpticalElementView {
 
   private readonly glass: HalfPlaneGlass;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(glass: HalfPlaneGlass, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    glass: HalfPlaneGlass,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.glass = glass;
     this.modelViewTransform = modelViewTransform;
+
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.glassPath = new Path(null, {
       fill: glassFill(glass.refIndex),
@@ -66,6 +75,7 @@ export class HalfPlaneGlassView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => glass.p2,
@@ -77,6 +87,7 @@ export class HalfPlaneGlassView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      handlesVisibleProperty,
     );
 
     // Glass fill drawn first (behind everything)

--- a/src/common/view/glass/IdealLensView.ts
+++ b/src/common/view/glass/IdealLensView.ts
@@ -25,8 +25,6 @@ import {
 import opticsLab from "../../../OpticsLabNamespace.js";
 import type { IdealLens } from "../../model/glass/IdealLens.js";
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
-import { focalMarkersVisibleProperty } from "../FocalMarkersVisibleProperty.js";
-import { handlesVisibleProperty } from "../HandlesVisibleProperty.js";
 import {
   attachTranslationDrag,
   buildDiamondShape,
@@ -35,6 +33,7 @@ import {
   type DragHandle,
   makeEndpointHandle,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class IdealLensView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -49,7 +48,12 @@ export class IdealLensView extends BaseOpticalElementView {
 
   private readonly lens: IdealLens;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(lens: IdealLens, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    lens: IdealLens,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions: ViewOptionsModel,
+  ) {
     super();
     this.lens = lens;
     this.modelViewTransform = modelViewTransform;
@@ -86,6 +90,7 @@ export class IdealLensView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => lens.p2,
@@ -97,6 +102,7 @@ export class IdealLensView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
 
     this.addChild(this.linePath);
@@ -106,9 +112,9 @@ export class IdealLensView extends BaseOpticalElementView {
     this.excludeFromSelectionBounds(this.focalMarker1);
     this.excludeFromSelectionBounds(this.focalMarker2);
     this.addChild(this.bodyHitPath);
-    this.trackLinkAttribute(handlesVisibleProperty, this.centerMarkPath, "visible");
-    this.trackLinkAttribute(focalMarkersVisibleProperty, this.focalMarker1, "visible");
-    this.trackLinkAttribute(focalMarkersVisibleProperty, this.focalMarker2, "visible");
+    this.trackLinkAttribute(viewOptions.handlesVisibleProperty, this.centerMarkPath, "visible");
+    this.trackLinkAttribute(viewOptions.focalMarkersVisibleProperty, this.focalMarker1, "visible");
+    this.trackLinkAttribute(viewOptions.focalMarkersVisibleProperty, this.focalMarker2, "visible");
     this.addChild(this.handle1);
     this.addChild(this.handle2);
     this.addChild(this.arrowPath);

--- a/src/common/view/glass/PlanoLensView.ts
+++ b/src/common/view/glass/PlanoLensView.ts
@@ -16,6 +16,7 @@ import { Tandem } from "scenerystack/tandem";
 import opticsLab from "../../../OpticsLabNamespace.js";
 import type { GlassPathPoint } from "../../model/glass/Glass.js";
 import type { SphericalLens } from "../../model/glass/SphericalLens.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 import { SphericalLensView } from "./SphericalLensView.js";
 
 /** Minimum distance (model units) the apex must sit past the corner midpoint. */
@@ -31,8 +32,13 @@ export class PlanoLensView extends SphericalLensView {
    */
   private readonly apexReqSign: 1 | -1;
 
-  public constructor(lens: SphericalLens, modelViewTransform: ModelViewTransform2, tandem: Tandem = Tandem.OPT_OUT) {
-    super(lens, modelViewTransform, tandem);
+  public constructor(
+    lens: SphericalLens,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem = Tandem.OPT_OUT,
+    viewOptions?: ViewOptionsModel,
+  ) {
+    super(lens, modelViewTransform, tandem, viewOptions);
 
     // The left surface is always flat — hide its curvature handle.
     this.curvatureHandleR1.visible = false;

--- a/src/common/view/glass/SphericalLensView.ts
+++ b/src/common/view/glass/SphericalLensView.ts
@@ -12,6 +12,7 @@
  * Handle vertices are the 4 non-arc path points (indices 0, 1, 3, 4).
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Circle, Path, RichDragListener } from "scenerystack/scenery";
@@ -32,9 +33,8 @@ import {
 import opticsLab from "../../../OpticsLabNamespace.js";
 import type { GlassPathPoint } from "../../model/glass/Glass.js";
 import type { SphericalLens } from "../../model/glass/SphericalLens.js";
-import { focalMarkersVisibleProperty } from "../FocalMarkersVisibleProperty.js";
-import { handlesVisibleProperty } from "../HandlesVisibleProperty.js";
 import { buildDiamondShape, createHandle } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 import { GlassView } from "./GlassView.js";
 
 /**
@@ -69,10 +69,17 @@ export class SphericalLensView extends GlassView {
   protected readonly curvatureHandleR2: Circle; // path[2] – right surface
 
   protected readonly lens: SphericalLens;
-  public constructor(lens: SphericalLens, modelViewTransform: ModelViewTransform2, tandem: Tandem = Tandem.OPT_OUT) {
+  public constructor(
+    lens: SphericalLens,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem = Tandem.OPT_OUT,
+    viewOptions?: ViewOptionsModel,
+  ) {
     // Pass empty handleVerts → GlassView creates no default handles.
-    super(lens, modelViewTransform, tandem, []);
+    super(lens, modelViewTransform, tandem, [], viewOptions?.handlesVisibleProperty);
     this.lens = lens;
+
+    const focalMarkersVisibleProperty = viewOptions?.focalMarkersVisibleProperty ?? new BooleanProperty(true);
 
     // ── Focal-point markers ────────────────────────────────────────────────
     this.focalFront = new Path(null, { fill: OpticsLabColors.focalMarkerFillProperty });
@@ -93,7 +100,7 @@ export class SphericalLensView extends GlassView {
     );
     this.widthHandles = this.widthCornerIndices.map((ci) => {
       const pos = corners[ci] ?? { x: 0, y: 0 };
-      const handle = createHandle(pos, modelViewTransform);
+      const handle = createHandle(pos, modelViewTransform, this.handlesVisibleProperty);
       this.addChild(handle);
       // Top corners (near p1) drag in -da direction to increase height;
       // bottom corners (near p2) drag in +da direction.
@@ -124,8 +131,8 @@ export class SphericalLensView extends GlassView {
       pickable: false,
     });
     this.addChild(this.rotationIndicator);
-    this.trackLinkAttribute(handlesVisibleProperty, this.rotationHandle, "visible");
-    this.trackLinkAttribute(handlesVisibleProperty, this.rotationIndicator, "visible");
+    this.trackLinkAttribute(this.handlesVisibleProperty, this.rotationHandle, "visible");
+    this.trackLinkAttribute(this.handlesVisibleProperty, this.rotationIndicator, "visible");
     this.attachRotationDrag();
 
     // ── Curvature handles ──────────────────────────────────────────────────
@@ -143,7 +150,7 @@ export class SphericalLensView extends GlassView {
       focusable: true,
     });
     this.addChild(this.curvatureHandleR2);
-    this.trackLinkAttribute(handlesVisibleProperty, this.curvatureHandleR2, "visible");
+    this.trackLinkAttribute(this.handlesVisibleProperty, this.curvatureHandleR2, "visible");
     this.attachCurvatureDrag(this.curvatureHandleR2, "r2");
 
     this.curvatureHandleR1 = new Circle(HANDLE_RADIUS, {
@@ -157,7 +164,7 @@ export class SphericalLensView extends GlassView {
       focusable: true,
     });
     this.addChild(this.curvatureHandleR1);
-    this.trackLinkAttribute(handlesVisibleProperty, this.curvatureHandleR1, "visible");
+    this.trackLinkAttribute(this.handlesVisibleProperty, this.curvatureHandleR1, "visible");
     this.attachCurvatureDrag(this.curvatureHandleR1, "r1");
 
     // Initial draw

--- a/src/common/view/glass/SymmetricLensView.ts
+++ b/src/common/view/glass/SymmetricLensView.ts
@@ -22,6 +22,7 @@ import { Tandem } from "scenerystack/tandem";
 import opticsLab from "../../../OpticsLabNamespace.js";
 import type { GlassPathPoint } from "../../model/glass/Glass.js";
 import type { SphericalLens } from "../../model/glass/SphericalLens.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 import { SphericalLensView } from "./SphericalLensView.js";
 
 /** Minimum distance (model units) the apex must sit past the corner midpoint. */
@@ -31,8 +32,13 @@ export class SymmetricLensView extends SphericalLensView {
   /** +1 for BiconvexLens (r1 > 0), −1 for BiconcaveLens (r1 < 0). */
   private readonly rSign: 1 | -1;
 
-  public constructor(lens: SphericalLens, modelViewTransform: ModelViewTransform2, tandem: Tandem = Tandem.OPT_OUT) {
-    super(lens, modelViewTransform, tandem);
+  public constructor(
+    lens: SphericalLens,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem = Tandem.OPT_OUT,
+    viewOptions?: ViewOptionsModel,
+  ) {
+    super(lens, modelViewTransform, tandem, viewOptions);
     const { r1 } = lens.getDR1R2();
     this.rSign = r1 >= 0 ? 1 : -1;
   }

--- a/src/common/view/glass/TypedPrismView.ts
+++ b/src/common/view/glass/TypedPrismView.ts
@@ -34,8 +34,8 @@ import {
 } from "../../../OpticsLabConstants.js";
 import opticsLab from "../../../OpticsLabNamespace.js";
 import type { Glass } from "../../model/glass/Glass.js";
-import { handlesVisibleProperty } from "../HandlesVisibleProperty.js";
 import { createHandle } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 import { GlassView } from "./GlassView.js";
 
 /**
@@ -59,9 +59,14 @@ export class TypedPrismView extends GlassView {
   private readonly rotationHandle: Circle;
   private readonly rotationIndicator: Path;
 
-  public constructor(glass: Glass, modelViewTransform: ModelViewTransform2, tandem: Tandem = Tandem.OPT_OUT) {
+  public constructor(
+    glass: Glass,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem = Tandem.OPT_OUT,
+    viewOptions?: ViewOptionsModel,
+  ) {
     // Pass empty handleVerts so GlassView creates no default vertex handles.
-    super(glass, modelViewTransform, tandem, []);
+    super(glass, modelViewTransform, tandem, [], viewOptions?.handlesVisibleProperty);
 
     const path = glass.path;
     const n = path.length;
@@ -76,7 +81,7 @@ export class TypedPrismView extends GlassView {
       if (!vert) {
         continue;
       }
-      const handle = createHandle({ x: vert.x, y: vert.y }, modelViewTransform);
+      const handle = createHandle({ x: vert.x, y: vert.y }, modelViewTransform, this.handlesVisibleProperty);
       if (wh !== null) {
         this.attachWidthHeightDrag(handle, i, wh, isDove);
       } else {
@@ -110,8 +115,8 @@ export class TypedPrismView extends GlassView {
     });
     this.addChild(this.rotationIndicator);
 
-    this.trackLinkAttribute(handlesVisibleProperty, this.rotationHandle, "visible");
-    this.trackLinkAttribute(handlesVisibleProperty, this.rotationIndicator, "visible");
+    this.trackLinkAttribute(this.handlesVisibleProperty, this.rotationHandle, "visible");
+    this.trackLinkAttribute(this.handlesVisibleProperty, this.rotationIndicator, "visible");
 
     this.attachRotationDrag();
 

--- a/src/common/view/gratings/ReflectionGratingView.ts
+++ b/src/common/view/gratings/ReflectionGratingView.ts
@@ -5,6 +5,7 @@
  * segment with angled hatch marks to represent the grooved reflective surface.
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -26,6 +27,7 @@ import {
   type DragHandle,
   makeEndpointHandle,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class ReflectionGratingView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -39,10 +41,16 @@ export class ReflectionGratingView extends BaseOpticalElementView {
 
   private readonly grating: ReflectionGrating;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(grating: ReflectionGrating, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    grating: ReflectionGrating,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.grating = grating;
     this.modelViewTransform = modelViewTransform;
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.backPath = new Path(null, {
       stroke: OpticsLabColors.mirrorBackStrokeProperty,
@@ -72,6 +80,7 @@ export class ReflectionGratingView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => grating.p2,
@@ -83,6 +92,7 @@ export class ReflectionGratingView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.backPath);

--- a/src/common/view/gratings/TransmissionGratingView.ts
+++ b/src/common/view/gratings/TransmissionGratingView.ts
@@ -5,6 +5,7 @@
  * with short perpendicular tick marks to represent the periodic groove structure.
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -25,6 +26,7 @@ import {
   type DragHandle,
   makeEndpointHandle,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class TransmissionGratingView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -37,10 +39,16 @@ export class TransmissionGratingView extends BaseOpticalElementView {
 
   private readonly grating: TransmissionGrating;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(grating: TransmissionGrating, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    grating: TransmissionGrating,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.grating = grating;
     this.modelViewTransform = modelViewTransform;
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.bodyPath = new Path(null, {
       stroke: OpticsLabColors.glassStrokeProperty,
@@ -64,6 +72,7 @@ export class TransmissionGratingView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => grating.p2,
@@ -75,6 +84,7 @@ export class TransmissionGratingView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.bodyPath);

--- a/src/common/view/guides/TrackView.ts
+++ b/src/common/view/guides/TrackView.ts
@@ -5,6 +5,7 @@
  * Registers with the TrackRegistry so other elements can snap to it.
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -21,6 +22,7 @@ import {
   type DragHandle,
   makeEndpointHandle,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 const TRACK_LINE_WIDTH = 2;
 const TRACK_LINE_DASH = [8, 4];
@@ -34,10 +36,16 @@ export class TrackView extends BaseOpticalElementView {
 
   private readonly track: TrackElement;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(track: TrackElement, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    track: TrackElement,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.track = track;
     this.modelViewTransform = modelViewTransform;
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.trackPath = new Path(null, {
       stroke: OpticsLabColors.trackStrokeProperty,
@@ -57,6 +65,7 @@ export class TrackView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => track.p2,
@@ -68,6 +77,7 @@ export class TrackView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.trackPath);

--- a/src/common/view/light-sources/ArcLightSourceView.ts
+++ b/src/common/view/light-sources/ArcLightSourceView.ts
@@ -32,6 +32,7 @@ import type { ArcLightSource } from "../../model/light-sources/ArcLightSource.js
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
 import { sceneHistoryRegistry } from "../SceneHistoryRegistry.js";
 import { attachTranslationDrag, createHandle } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 // ── Helper: build an arc (polyline) by sampling in model space ───────────────
 
@@ -121,7 +122,12 @@ export class ArcLightSourceView extends BaseOpticalElementView {
 
   private readonly source: ArcLightSource;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(source: ArcLightSource, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    source: ArcLightSource,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions: ViewOptionsModel,
+  ) {
     super();
     this.source = source;
     this.modelViewTransform = modelViewTransform;
@@ -151,8 +157,8 @@ export class ArcLightSourceView extends BaseOpticalElementView {
       cursor: "grab",
     });
 
-    this.dirHandle = createHandle(this.dirHandlePos(), modelViewTransform);
-    this.spreadHandle = createHandle(this.spreadHandlePos(), modelViewTransform);
+    this.dirHandle = createHandle(this.dirHandlePos(), modelViewTransform, viewOptions.handlesVisibleProperty);
+    this.spreadHandle = createHandle(this.spreadHandlePos(), modelViewTransform, viewOptions.handlesVisibleProperty);
 
     this.addChild(this.sectorPath);
     this.addChild(this.rimPath);

--- a/src/common/view/light-sources/BeamSourceView.ts
+++ b/src/common/view/light-sources/BeamSourceView.ts
@@ -3,6 +3,7 @@
  * Model coords in metres (y-up); view coords in pixels (y-down).
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -19,6 +20,7 @@ import {
   type DragHandle,
   makeEndpointHandle,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class BeamSourceView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -30,10 +32,16 @@ export class BeamSourceView extends BaseOpticalElementView {
 
   private readonly source: BeamSource;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(source: BeamSource, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    source: BeamSource,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.source = source;
     this.modelViewTransform = modelViewTransform;
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.shieldPath = new Path(null, {
       lineWidth: BEAM_SOURCE_SHIELD_WIDTH,
@@ -60,6 +68,7 @@ export class BeamSourceView extends BaseOpticalElementView {
       rebuild,
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => source.p2,
@@ -69,6 +78,7 @@ export class BeamSourceView extends BaseOpticalElementView {
       rebuild,
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.shieldPath);

--- a/src/common/view/light-sources/ContinuousSpectrumSourceView.ts
+++ b/src/common/view/light-sources/ContinuousSpectrumSourceView.ts
@@ -8,6 +8,7 @@
  *   • Draggable handle circle at p2 for direction control.
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -27,6 +28,7 @@ import opticsLab from "../../../OpticsLabNamespace.js";
 import type { ContinuousSpectrumSource } from "../../model/light-sources/ContinuousSpectrumSource.js";
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
 import { attachTranslationDrag, type DragHandle, makeEndpointHandle } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class ContinuousSpectrumSourceView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -39,10 +41,16 @@ export class ContinuousSpectrumSourceView extends BaseOpticalElementView {
 
   private readonly source: ContinuousSpectrumSource;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(source: ContinuousSpectrumSource, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    source: ContinuousSpectrumSource,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.source = source;
     this.modelViewTransform = modelViewTransform;
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     // Rainbow disc: one arc path per spectrum sample wavelength.
     const arcSpan = (Math.PI * 2) / CONT_SPECTRUM_SAMPLE_WL.length;
@@ -88,6 +96,7 @@ export class ContinuousSpectrumSourceView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("directionDragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.dirPath);

--- a/src/common/view/light-sources/DivergentBeamView.ts
+++ b/src/common/view/light-sources/DivergentBeamView.ts
@@ -6,6 +6,7 @@
  * the divergence half-angle at each endpoint, and endpoint drag handles.
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -27,6 +28,7 @@ import {
   type DragHandle,
   makeEndpointHandle,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class DivergentBeamView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -39,10 +41,16 @@ export class DivergentBeamView extends BaseOpticalElementView {
 
   private readonly source: DivergentBeam;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(source: DivergentBeam, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    source: DivergentBeam,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.source = source;
     this.modelViewTransform = modelViewTransform;
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.shieldPath = new Path(null, {
       lineWidth: BEAM_SOURCE_SHIELD_WIDTH,
@@ -72,6 +80,7 @@ export class DivergentBeamView extends BaseOpticalElementView {
       rebuild,
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => source.p2,
@@ -81,6 +90,7 @@ export class DivergentBeamView extends BaseOpticalElementView {
       rebuild,
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.shieldPath);

--- a/src/common/view/light-sources/SingleRaySourceView.ts
+++ b/src/common/view/light-sources/SingleRaySourceView.ts
@@ -3,6 +3,7 @@
  * Model coords are in metres (y-up); view coords in pixels (y-down).
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -20,6 +21,7 @@ import opticsLab from "../../../OpticsLabNamespace.js";
 import type { SingleRaySource } from "../../model/light-sources/SingleRaySource.js";
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
 import { attachTranslationDrag, type DragHandle, makeEndpointHandle } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class SingleRaySourceView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -30,10 +32,16 @@ export class SingleRaySourceView extends BaseOpticalElementView {
 
   private readonly source: SingleRaySource;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(source: SingleRaySource, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    source: SingleRaySource,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.source = source;
     this.modelViewTransform = modelViewTransform;
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.originPath = new Path(null, {
       lineWidth: SINGLE_RAY_ORIGIN_STROKE_WIDTH,
@@ -52,6 +60,7 @@ export class SingleRaySourceView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("directionDragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.dirPath);

--- a/src/common/view/mirrors/AperturedParabolicMirrorView.ts
+++ b/src/common/view/mirrors/AperturedParabolicMirrorView.ts
@@ -24,7 +24,6 @@ import type { AperturedParabolicMirror } from "../../model/mirrors/AperturedPara
 import type { Point } from "../../model/optics/Geometry.js";
 import { distance } from "../../model/optics/Geometry.js";
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
-import { focalMarkersVisibleProperty } from "../FocalMarkersVisibleProperty.js";
 import {
   attachCurvatureHandleDrag,
   attachTranslationDrag,
@@ -35,6 +34,7 @@ import {
   makeEndpointHandle,
   projectPointOntoPerpendicularBisector,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 /** Split model-space points into left arm / right arm around the central aperture. */
 function splitAroundAperture(
@@ -74,7 +74,12 @@ export class AperturedParabolicMirrorView extends BaseOpticalElementView {
 
   private readonly mirror: AperturedParabolicMirror;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(mirror: AperturedParabolicMirror, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    mirror: AperturedParabolicMirror,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions: ViewOptionsModel,
+  ) {
     super();
     this.mirror = mirror;
     this.modelViewTransform = modelViewTransform;
@@ -127,6 +132,7 @@ export class AperturedParabolicMirrorView extends BaseOpticalElementView {
       () => this.rebuild(),
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => mirror.p2,
@@ -137,8 +143,9 @@ export class AperturedParabolicMirrorView extends BaseOpticalElementView {
       () => this.rebuild(),
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
-    this.handle3 = createHandle(mirror.p3, modelViewTransform);
+    this.handle3 = createHandle(mirror.p3, modelViewTransform, viewOptions.handlesVisibleProperty);
 
     this.addChild(this.bodyHitPathLeft);
     this.addChild(this.bodyHitPathRight);
@@ -148,7 +155,7 @@ export class AperturedParabolicMirrorView extends BaseOpticalElementView {
     this.addChild(this.frontPathRight);
     this.addChild(this.focalMarker);
     this.excludeFromSelectionBounds(this.focalMarker);
-    this.trackLinkAttribute(focalMarkersVisibleProperty, this.focalMarker, "visible");
+    this.trackLinkAttribute(viewOptions.focalMarkersVisibleProperty, this.focalMarker, "visible");
     this.addChild(this.handle1);
     this.addChild(this.handle2);
     this.addChild(this.handle3);

--- a/src/common/view/mirrors/ArcMirrorView.ts
+++ b/src/common/view/mirrors/ArcMirrorView.ts
@@ -21,7 +21,6 @@ import opticsLab from "../../../OpticsLabNamespace.js";
 import type { ArcMirror } from "../../model/mirrors/ArcMirror.js";
 import { circumcenter, sampleArcPoints } from "../../model/optics/Geometry.js";
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
-import { focalMarkersVisibleProperty } from "../FocalMarkersVisibleProperty.js";
 import {
   attachCurvatureHandleDrag,
   attachTranslationDrag,
@@ -32,6 +31,7 @@ import {
   makeEndpointHandle,
   projectPointOntoPerpendicularBisector,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class ArcMirrorView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -45,7 +45,12 @@ export class ArcMirrorView extends BaseOpticalElementView {
 
   private readonly mirror: ArcMirror;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(mirror: ArcMirror, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    mirror: ArcMirror,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions: ViewOptionsModel,
+  ) {
     super();
     this.mirror = mirror;
     this.modelViewTransform = modelViewTransform;
@@ -82,6 +87,7 @@ export class ArcMirrorView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => mirror.p2,
@@ -94,15 +100,16 @@ export class ArcMirrorView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
-    this.handle3 = createHandle(mirror.p3, modelViewTransform);
+    this.handle3 = createHandle(mirror.p3, modelViewTransform, viewOptions.handlesVisibleProperty);
 
     this.addChild(this.bodyHitPath);
     this.addChild(this.backPath);
     this.addChild(this.frontPath);
     this.addChild(this.focalMarker);
     this.excludeFromSelectionBounds(this.focalMarker);
-    this.trackLinkAttribute(focalMarkersVisibleProperty, this.focalMarker, "visible");
+    this.trackLinkAttribute(viewOptions.focalMarkersVisibleProperty, this.focalMarker, "visible");
     this.addChild(this.handle1);
     this.addChild(this.handle2);
     this.addChild(this.handle3);

--- a/src/common/view/mirrors/BeamSplitterView.ts
+++ b/src/common/view/mirrors/BeamSplitterView.ts
@@ -6,6 +6,7 @@
  * Endpoint handles and a body-drag region let the user reposition the element.
  */
 
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -22,6 +23,7 @@ import {
   type DragHandle,
   makeEndpointHandle,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class BeamSplitterView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -33,10 +35,16 @@ export class BeamSplitterView extends BaseOpticalElementView {
 
   private readonly splitter: BeamSplitterElement;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(splitter: BeamSplitterElement, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    splitter: BeamSplitterElement,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.splitter = splitter;
     this.modelViewTransform = modelViewTransform;
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.backPath = new Path(null, {
       stroke: OpticsLabColors.beamSplitterBackStrokeProperty,
@@ -61,6 +69,7 @@ export class BeamSplitterView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => splitter.p2,
@@ -72,6 +81,7 @@ export class BeamSplitterView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.backPath);

--- a/src/common/view/mirrors/IdealCurvedMirrorView.ts
+++ b/src/common/view/mirrors/IdealCurvedMirrorView.ts
@@ -25,7 +25,6 @@ import {
 import opticsLab from "../../../OpticsLabNamespace.js";
 import type { IdealCurvedMirror } from "../../model/mirrors/IdealCurvedMirror.js";
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
-import { focalMarkersVisibleProperty } from "../FocalMarkersVisibleProperty.js";
 import {
   attachTranslationDrag,
   buildDiamondShape,
@@ -34,6 +33,7 @@ import {
   type DragHandle,
   makeEndpointHandle,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class IdealCurvedMirrorView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -48,7 +48,12 @@ export class IdealCurvedMirrorView extends BaseOpticalElementView {
 
   private readonly mirror: IdealCurvedMirror;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(mirror: IdealCurvedMirror, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    mirror: IdealCurvedMirror,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions: ViewOptionsModel,
+  ) {
     super();
     this.mirror = mirror;
     this.modelViewTransform = modelViewTransform;
@@ -85,6 +90,7 @@ export class IdealCurvedMirrorView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => mirror.p2,
@@ -96,6 +102,7 @@ export class IdealCurvedMirrorView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
 
     this.addChild(this.linePath);
@@ -105,8 +112,8 @@ export class IdealCurvedMirrorView extends BaseOpticalElementView {
     this.addChild(this.focalMarker2);
     this.excludeFromSelectionBounds(this.focalMarker1);
     this.excludeFromSelectionBounds(this.focalMarker2);
-    this.trackLinkAttribute(focalMarkersVisibleProperty, this.focalMarker1, "visible");
-    this.trackLinkAttribute(focalMarkersVisibleProperty, this.focalMarker2, "visible");
+    this.trackLinkAttribute(viewOptions.focalMarkersVisibleProperty, this.focalMarker1, "visible");
+    this.trackLinkAttribute(viewOptions.focalMarkersVisibleProperty, this.focalMarker2, "visible");
     this.addChild(this.bodyHitPath);
     this.addChild(this.handle1);
     this.addChild(this.handle2);

--- a/src/common/view/mirrors/ParabolicMirrorView.ts
+++ b/src/common/view/mirrors/ParabolicMirrorView.ts
@@ -21,7 +21,6 @@ import opticsLab from "../../../OpticsLabNamespace.js";
 import type { ParabolicMirror } from "../../model/mirrors/ParabolicMirror.js";
 import type { Point } from "../../model/optics/Geometry.js";
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
-import { focalMarkersVisibleProperty } from "../FocalMarkersVisibleProperty.js";
 import {
   attachCurvatureHandleDrag,
   attachTranslationDrag,
@@ -32,6 +31,7 @@ import {
   makeEndpointHandle,
   projectPointOntoPerpendicularBisector,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 /**
  * Compute the parabola's polyline approximation in model coordinates.
@@ -80,7 +80,12 @@ export class ParabolicMirrorView extends BaseOpticalElementView {
 
   private readonly mirror: ParabolicMirror;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(mirror: ParabolicMirror, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    mirror: ParabolicMirror,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions: ViewOptionsModel,
+  ) {
     super();
     this.mirror = mirror;
     this.modelViewTransform = modelViewTransform;
@@ -115,6 +120,7 @@ export class ParabolicMirrorView extends BaseOpticalElementView {
       () => this.rebuild(),
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => mirror.p2,
@@ -125,15 +131,16 @@ export class ParabolicMirrorView extends BaseOpticalElementView {
       () => this.rebuild(),
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      viewOptions.handlesVisibleProperty,
     );
-    this.handle3 = createHandle(mirror.p3, modelViewTransform);
+    this.handle3 = createHandle(mirror.p3, modelViewTransform, viewOptions.handlesVisibleProperty);
 
     this.addChild(this.bodyHitPath);
     this.addChild(this.backPath);
     this.addChild(this.frontPath);
     this.addChild(this.focalMarker);
     this.excludeFromSelectionBounds(this.focalMarker);
-    this.trackLinkAttribute(focalMarkersVisibleProperty, this.focalMarker, "visible");
+    this.trackLinkAttribute(viewOptions.focalMarkersVisibleProperty, this.focalMarker, "visible");
     this.addChild(this.handle1);
     this.addChild(this.handle2);
     this.addChild(this.handle3);

--- a/src/common/view/mirrors/SegmentMirrorView.ts
+++ b/src/common/view/mirrors/SegmentMirrorView.ts
@@ -1,3 +1,4 @@
+import { BooleanProperty } from "scenerystack/axon";
 import { Shape } from "scenerystack/kite";
 import type { ModelViewTransform2 } from "scenerystack/phetcommon";
 import { Path, type RichDragListener } from "scenerystack/scenery";
@@ -14,6 +15,7 @@ import {
   type DragHandle,
   makeEndpointHandle,
 } from "../ViewHelpers.js";
+import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 
 export class SegmentMirrorView extends BaseOpticalElementView {
   public readonly bodyDragListener: RichDragListener;
@@ -25,10 +27,16 @@ export class SegmentMirrorView extends BaseOpticalElementView {
 
   private readonly mirror: SegmentMirror;
   private readonly modelViewTransform: ModelViewTransform2;
-  public constructor(mirror: SegmentMirror, modelViewTransform: ModelViewTransform2, tandem: Tandem) {
+  public constructor(
+    mirror: SegmentMirror,
+    modelViewTransform: ModelViewTransform2,
+    tandem: Tandem,
+    viewOptions?: ViewOptionsModel,
+  ) {
     super();
     this.mirror = mirror;
     this.modelViewTransform = modelViewTransform;
+    const handlesVisibleProperty = viewOptions?.handlesVisibleProperty ?? new BooleanProperty(true);
 
     this.backPath = new Path(null, {
       stroke: OpticsLabColors.mirrorBackStrokeProperty,
@@ -53,6 +61,7 @@ export class SegmentMirrorView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle1DragListener"),
+      handlesVisibleProperty,
     );
     this.handle2 = makeEndpointHandle(
       () => mirror.p2,
@@ -64,6 +73,7 @@ export class SegmentMirrorView extends BaseOpticalElementView {
       },
       modelViewTransform,
       tandem.createTandem("handle2DragListener"),
+      handlesVisibleProperty,
     );
 
     this.addChild(this.backPath);

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,11 +12,7 @@ import "./brand.js";
 import { onReadyToLaunch, PreferencesModel, Sim } from "scenerystack/sim";
 import { Tandem } from "scenerystack/tandem";
 import type { ComponentKey } from "./common/view/ComponentCarousel.js";
-import { focalMarkersVisibleProperty } from "./common/view/FocalMarkersVisibleProperty.js";
-import { handlesVisibleProperty } from "./common/view/HandlesVisibleProperty.js";
 import { KeyboardShortcutsNode } from "./common/view/KeyboardShortcutsNode.js";
-import { rayArrowsVisibleProperty } from "./common/view/RayArrowsVisibleProperty.js";
-import { rayStubLengthPxProperty, rayStubsEnabledProperty } from "./common/view/RayStubsProperty.js";
 import { DiffractionScreen } from "./diffraction/DiffractionScreen.js";
 import { StringManager } from "./i18n/StringManager.js";
 import { IntroScreen } from "./intro/IntroScreen.js";
@@ -42,12 +38,6 @@ import opticsLabQueryParameters from "./preferences/opticsLabQueryParameters.js"
 import { PresetsScreen } from "./presets/PresetsScreen.js";
 
 onReadyToLaunch(() => {
-  handlesVisibleProperty.value = opticsLabQueryParameters.showHandles;
-  focalMarkersVisibleProperty.value = opticsLabQueryParameters.showFocalMarkers;
-  rayArrowsVisibleProperty.value = opticsLabQueryParameters.showRayArrows;
-  rayStubsEnabledProperty.value = opticsLabQueryParameters.showRayStubs;
-  rayStubLengthPxProperty.value = opticsLabQueryParameters.rayStubLength;
-
   const stringManager = StringManager.getInstance();
   const opticsLabPreferences = new OpticsLabPreferencesModel(Tandem.ROOT.createTandem(TANDEM_OPTICS_LAB_PREFERENCES));
   const screenNames = stringManager.getScreenNames();

--- a/src/presets/PresetsScreenView.ts
+++ b/src/presets/PresetsScreenView.ts
@@ -84,7 +84,7 @@ export class PresetsScreenView extends RayTracingCommonView {
         // Tandem names must be camelCase with no hyphens; convert "element-2" → "element2"
         const tandemName = element.id.replace(/-(\d+)/g, "$1");
         const elementTandem = viewTandem?.createTandem(tandemName) ?? Tandem.OPTIONAL;
-        const view = createOpticalElementView(element, this.modelViewTransform, elementTandem);
+        const view = createOpticalElementView(element, this.modelViewTransform, elementTandem, this.viewOptions);
         if (view) {
           this.elementTandemMap.set(element.id, elementTandem);
           this._setupView(element, view);

--- a/tests/memory-leak.test.ts
+++ b/tests/memory-leak.test.ts
@@ -46,6 +46,11 @@ import { type ComponentKey, createDefaultElement } from "../src/common/model/Com
 import { OpticsScene } from "../src/common/model/optics/OpticsScene.js";
 import { createOpticalElementView } from "../src/common/view/OpticalElementViewFactory.js";
 import { trackRegistry } from "../src/common/view/TrackRegistry.js";
+import { ViewOptionsModel } from "../src/common/view/ViewOptionsModel.js";
+
+// Shared default ViewOptionsModel used across all tests that construct views.
+// Not disposed between tests — it acts as a long-lived sentinel with default values.
+const viewOptions = new ViewOptionsModel();
 
 // All component keys available in the factory — every element type must be covered.
 const ALL_KEYS: ComponentKey[] = [
@@ -141,7 +146,7 @@ function createWithView(
   mvt: ModelViewTransform2,
 ): { elementRef: WeakRef<object>; viewRef: WeakRef<object> | null } {
   const el = createDefaultElement(key, 0, 0);
-  const view = createOpticalElementView(el, mvt, Tandem.OPT_OUT);
+  const view = createOpticalElementView(el, mvt, Tandem.OPT_OUT, viewOptions);
   const elementRef = new WeakRef<object>(el);
   const viewRef = view ? new WeakRef<object>(view) : null;
   view?.dispose();
@@ -160,7 +165,7 @@ function createWithViewAndExternalListener(
   mvt: ModelViewTransform2,
 ): { elementRef: WeakRef<object>; viewRef: WeakRef<object> | null } {
   const el = createDefaultElement(key, 0, 0);
-  const view = createOpticalElementView(el, mvt, Tandem.OPT_OUT);
+  const view = createOpticalElementView(el, mvt, Tandem.OPT_OUT, viewOptions);
   const elementRef = new WeakRef<object>(el);
   const viewRef = view ? new WeakRef<object>(view) : null;
 
@@ -189,7 +194,7 @@ function createWithViewReversedDisposal(
   mvt: ModelViewTransform2,
 ): { elementRef: WeakRef<object>; viewRef: WeakRef<object> | null } {
   const el = createDefaultElement(key, 0, 0);
-  const view = createOpticalElementView(el, mvt, Tandem.OPT_OUT);
+  const view = createOpticalElementView(el, mvt, Tandem.OPT_OUT, viewOptions);
   const elementRef = new WeakRef<object>(el);
   const viewRef = view ? new WeakRef<object>(view) : null;
   // Reversed order: element disposed before its view.
@@ -208,7 +213,7 @@ function createWithViewSelected(
   mvt: ModelViewTransform2,
 ): { elementRef: WeakRef<object>; viewRef: WeakRef<object> | null } {
   const el = createDefaultElement(key, 0, 0);
-  const view = createOpticalElementView(el, mvt, Tandem.OPT_OUT);
+  const view = createOpticalElementView(el, mvt, Tandem.OPT_OUT, viewOptions);
   const elementRef = new WeakRef<object>(el);
   const viewRef = view ? new WeakRef<object>(view) : null;
   // Rebuild first so the selection frame has real child bounds to measure.
@@ -615,7 +620,7 @@ describe("Memory leak regression", () => {
     const el = createDefaultElement("track", 0, 0);
     const trackId = el.id;
 
-    const view = createOpticalElementView(el, mvt, Tandem.OPT_OUT);
+    const view = createOpticalElementView(el, mvt, Tandem.OPT_OUT, viewOptions);
 
     // Immediately after construction the track must appear in the registry.
     const registeredBefore = trackRegistry.getAllTracks().some((t) => t.id === trackId);

--- a/tests/memory-leak.test.ts
+++ b/tests/memory-leak.test.ts
@@ -50,7 +50,7 @@ import { ViewOptionsModel } from "../src/common/view/ViewOptionsModel.js";
 
 // Shared default ViewOptionsModel used across all tests that construct views.
 // Not disposed between tests — it acts as a long-lived sentinel with default values.
-const viewOptions = new ViewOptionsModel();
+const viewOptions: ViewOptionsModel = new ViewOptionsModel();
 
 // All component keys available in the factory — every element type must be covered.
 const ALL_KEYS: ComponentKey[] = [


### PR DESCRIPTION
## Summary
Consolidates five view-toggle properties (handles visibility, focal markers, ray arrows, ray stubs enabled, and ray stub length) from module-level singletons into a per-screen `ViewOptionsModel` class. This enables independent view settings per screen and makes these properties visible to PhET-iO instrumentation via Tandem.

## Key Changes

- **New `ViewOptionsModel` class** (`src/common/view/ViewOptionsModel.ts`):
  - Owns five view-state properties: `handlesVisibleProperty`, `focalMarkersVisibleProperty`, `rayArrowsVisibleProperty`, `rayStubsEnabledProperty`, and `rayStubLengthPxProperty`
  - Initializes from query parameters with optional Tandem instrumentation
  - Provides a `reset()` method for all properties

- **Updated `ElementRegistry`**:
  - Added `viewOptions: ViewOptionsModel` parameter to the `ElementDescriptor.createView` function signature
  - Updated all 30+ element view factory functions to accept and pass through the `viewOptions` parameter

- **Updated view classes** to accept `ViewOptionsModel`:
  - Light sources: `ArcLightSourceView`, `BeamSourceView`, `DivergentBeamView`, `SingleRaySourceView`, `ContinuousSpectrumSourceView`
  - Mirrors: `AperturedParabolicMirrorView`, `SegmentMirrorView`, `ArcMirrorView`, `ParabolicMirrorView`, `IdealCurvedMirrorView`, `BeamSplitterView`
  - Glass/Lenses: `IdealLensView`, `CircleGlassView`, `BiconvexLensView`, `BiconcaveLensView`, `PlanoLensView`, `SymmetricLensView`, `SphericalLensView`, `TypedPrismView`
  - Blockers/Detectors: `ApertureView`, `LineBlockerView`, `DetectorView`
  - Gratings: `ReflectionGratingView`, `TransmissionGratingView`
  - Guides: `TrackView`
  - Fiber: `FiberOpticView`

- **Updated `RayPropagationView`**:
  - Now accepts `ViewOptionsModel` in constructor
  - Uses instance properties instead of module-level singletons for ray visibility options

- **Updated `SimScreenView` (RayTracingCommonView)**:
  - Creates and owns a `ViewOptionsModel` instance
  - Passes it to element view factories and other components
  - Updated keyboard shortcut handler to use properties from the model

- **Updated `ToolsPanel`**:
  - Accepts and stores `ViewOptionsModel` instance
  - Uses instance properties instead of imported singletons

- **Removed module-level singleton imports**:
  - Eliminated imports of `HandlesVisibleProperty`, `FocalMarkersVisibleProperty`, `RayArrowsVisibleProperty`, and `RayStubsProperty` from multiple files
  - Replaced with type imports of `ViewOptionsModel`

- **Updated constants** (`OpticsLabConstants.ts`):
  - Added `RAY_STUB_LENGTH_DEFAULT_PX`, `RAY_STUB_LENGTH_MIN_PX`, and `RAY_STUB_LENGTH_MAX_PX` constants

## Implementation Details

- View classes that don't directly use visibility properties now receive `viewOptions` as an optional parameter with fallback to default `BooleanProperty(true)` for backward compatibility
- The `ViewOptionsModel` is instantiated once per screen and threaded through the view hierarchy
- Query parameter initialization is preserved, allowing configuration via URL parameters
- All properties support optional Tandem instrumentation for PhET-iO when a Tandem is provided

https://claude.ai/code/session_01Sng8UNQd8H93mf1pVxsoVo