### PR TITLE
Remove dead field initializer from RayTracer.callConfig

### DIFF
--- a/src/common/model/optics/RayTracer.ts
+++ b/src/common/model/optics/RayTracer.ts
@@ -184,10 +184,7 @@ export class RayTracer {
     };
   }
 
-  private readonly callConfig: RayCallConfig = {
-    partialReflectionEnabled: true,
-    lensRimBlockingEnabled: false,
-  };
+  private readonly callConfig: RayCallConfig;
 
   private processRayEntry(
     ray: SimulationRay,


### PR DESCRIPTION
The field declaration initializer was immediately overwritten by the
constructor assignment, causing two object allocations where only one
is needed. Replace the initializer value with a bare type declaration
and let the constructor assignment stand as the sole initialization.

https://claude.ai/code/session_012gy833dVTFvAh1nDzH5GiZ