### PR TITLE
Improve screen icons for physical accuracy

### DIFF
--- a/src/OpticsLabScreenIcons.ts
+++ b/src/OpticsLabScreenIcons.ts
@@ -1,11 +1,22 @@
 /**
  * Home screen and navigation bar icons for each OpticsLab screen.
  * Motifs use scenery nodes; ScreenIcon scales and centers them on the standard joist background.
+ *
+ * Each icon is a physically-motivated miniature of the optics that screen demonstrates:
+ *   • Intro       — a glass prism dispersing white light (violet deviates most, toward the base).
+ *   • Lab         — an optical bench imaging a point source through a lens onto a detector.
+ *   • Presets     — three cards, each a recognizable instrument (telescope, reflector, spectroscope).
+ *   • Diffraction — a grating producing a zeroth order plus symmetric, dispersed higher orders
+ *                   (red deviates most — the opposite ordering of a prism).
+ *
+ * Spectrum colors come from VisibleColor.wavelengthToColor so the rainbows match the sim's own
+ * ray rendering rather than being hand-tuned.
  */
 
 import type { Color } from "scenerystack";
 import { Shape } from "scenerystack/kite";
 import { Line, Node, Path } from "scenerystack/scenery";
+import { VisibleColor } from "scenerystack/scenery-phet";
 import { ScreenIcon } from "scenerystack/sim";
 import OpticsLabColors from "./OpticsLabColors.js";
 
@@ -16,110 +27,60 @@ const LENS_STROKE = "rgba(140, 200, 255, 0.95)";
 const LENS_FILL = "rgba(100, 180, 255, 0.35)";
 const MIRROR = "rgba(210, 210, 220, 0.9)";
 const ACCENT = "#ffaa55";
+const WHITE_RAY = "rgba(255, 255, 235, 0.95)";
+const GLASS_FILL = "rgba(120, 165, 215, 0.22)";
+const GLASS_STROKE = "rgba(165, 205, 248, 0.9)";
 const PRESET_ROW = "rgba(160, 175, 200, 0.55)";
 const PRESET_ROW_STROKE = "rgba(200, 210, 230, 0.5)";
 
-// ── Intro icon ─────────────────────────────────────────────────────────────────
-const INTRO_PRISM_FILL = "rgba(120, 165, 215, 0.22)";
-const INTRO_PRISM_STROKE = "rgba(165, 205, 248, 0.9)";
-const INTRO_PRISM_LINE_WIDTH = 3.5;
-const INTRO_WHITE_RAY_STROKE = "rgba(255, 255, 230, 0.95)";
-const INTRO_WHITE_RAY_LINE_WIDTH = 5;
-const INTRO_SPECTRUM_EXIT_X = 16;
-const INTRO_SPECTRUM_EXIT_Y = 4;
-const INTRO_SPECTRUM_LINE_WIDTH = 3.5;
-const INTRO_SPECTRUM: [number, string][] = [
-  [-46, "#9977ff"],
-  [-24, "#44aaff"],
-  [-2, "#55ee77"],
-  [20, "#ffee44"],
-  [42, "#ff7744"],
-];
+// Sampled visible wavelengths in nm, violet → red. Used to build accurate spectra.
+const SPECTRUM_WL = [410, 440, 470, 510, 555, 590, 650];
 
-// ── Lab icon ───────────────────────────────────────────────────────────────────
-const LAB_BENCH_STROKE = "rgba(135, 150, 182, 0.9)";
-const LAB_BENCH_LINE_WIDTH = 7;
-const LAB_TICK_X_POSITIONS = [-72, -48, -24, 0, 24, 48, 72];
-const LAB_TICK_STROKE = "rgba(85, 98, 128, 0.85)";
-const LAB_TICK_LINE_WIDTH = 1.5;
-const LAB_SOURCE_X = -78;
-const LAB_SOURCE_Y = 14;
-const LAB_SOURCE_GLOW_STROKE = "rgba(255, 195, 85, 0.9)";
-const LAB_SOURCE_RING1_STROKE = "rgba(255, 190, 80, 0.38)";
-const LAB_SOURCE_RING2_STROKE = "rgba(255, 185, 75, 0.16)";
-const LAB_STAND_STROKE = "rgba(108, 124, 158, 0.85)";
-const LAB_DETECTOR_X = 64;
-const LAB_DETECTOR_FILL = "rgba(75, 90, 122, 0.4)";
-const LAB_DETECTOR_STROKE = "rgba(152, 168, 205, 0.9)";
-const LAB_FOCAL_SPOT_Y = 12;
-const LAB_FOCAL_SPOT_STROKE = "rgba(85, 238, 119, 0.5)";
-const LAB_RAY_ROWS: [number, number, string][] = [
-  [4, 2, "rgba(85, 238, 119, 1.0)"],
-  [14, 8, "rgba(85, 238, 119, 0.85)"],
-  [24, 16, "rgba(85, 238, 119, 0.7)"],
-];
-
-// ── Presets icon ───────────────────────────────────────────────────────────────
-const PRESET_CARD_Y_CENTERS = [-36, 0, 36] as const;
-const PRESET_MINI_PRISM_FILL = "rgba(120, 160, 210, 0.18)";
-const PRESET_MINI_PRISM_STROKE = "rgba(155, 195, 238, 0.75)";
-const PRESET_WHITE_RAY_STROKE = "rgba(255, 255, 220, 0.9)";
-const PRESET_FOCAL_GLOW_STROKE = "rgba(255, 195, 85, 0.6)";
-const PRESET_SPECTRUM: [number, string][] = [
-  [-12, "#9977ff"],
-  [-4, "#44aaff"],
-  [4, "#55ee77"],
-  [12, "#ffee44"],
-  [20, "#ff7744"],
-];
-
-// ── Diffraction icon ───────────────────────────────────────────────────────────
-const DIFFRACTION_GRATING_Y0 = -48;
-const DIFFRACTION_GRATING_Y1 = 48;
-const DIFFRACTION_GRATING_SPACING = 9;
-const DIFFRACTION_GRATING_STROKE = "rgba(200, 210, 230, 0.85)";
-const DIFFRACTION_GRATING_LINE_WIDTH = 3;
-const DIFFRACTION_FAN_LENGTH = 78;
-const DIFFRACTION_ORDERS: { a: number; c: string }[] = [
-  { a: -0.42, c: "#66eeff" },
-  { a: -0.2, c: RAY_SOFT },
-  { a: 0, c: RAY },
-  { a: 0.22, c: "#eeff66" },
-  { a: 0.45, c: "#ffaaee" },
-];
+/** Returns an "rgba(...)" string for a wavelength, matching the sim's ray colors. */
+function wlColor(wavelengthNm: number, alpha = 1): string {
+  const c = VisibleColor.wavelengthToColor(wavelengthNm);
+  return `rgba(${c.r}, ${c.g}, ${c.b}, ${alpha})`;
+}
 
 function iconBackgroundFill(): Color | string {
   return OpticsLabColors.backgroundColorProperty.value;
 }
 
-// ── Intro: prism dispersing white light into a spectrum ────────────────────────
+// ── Intro: a prism dispersing white light into a spectrum ──────────────────────
+// Classic Newton geometry: a horizontal beam enters the left face, crosses the glass,
+// and fans out the right face deviated toward the base — violet bends most, red least.
 function wrapIntroIcon(): Node {
   const root = new Node();
 
-  // Glass prism (equilateral triangle, apex upper-left)
+  // Equilateral-ish glass prism, apex up, base along the bottom.
+  const apex = { x: 0, y: -50 };
+  const baseLeft = { x: -54, y: 42 };
+  const baseRight = { x: 54, y: 42 };
   root.addChild(
-    new Path(new Shape().moveTo(-12, -46).lineTo(-52, 36).lineTo(28, 36).close(), {
-      fill: INTRO_PRISM_FILL,
-      stroke: INTRO_PRISM_STROKE,
-      lineWidth: INTRO_PRISM_LINE_WIDTH,
-    }),
+    new Path(
+      new Shape().moveTo(apex.x, apex.y).lineTo(baseLeft.x, baseLeft.y).lineTo(baseRight.x, baseRight.y).close(),
+      { fill: GLASS_FILL, stroke: GLASS_STROKE, lineWidth: 3.5 },
+    ),
   );
 
-  // Incoming white ray from the left, hitting left prism face
+  // Entry/exit points where a horizontal internal ray crosses the two slanted faces.
+  const entry = { x: -28, y: -2 };
+  const exit = { x: 28, y: -2 };
+
+  // Incoming white ray, refracting downward at the left face into the horizontal internal ray.
+  root.addChild(new Line(-94, -26, entry.x, entry.y, { stroke: WHITE_RAY, lineWidth: 5, lineCap: "round" }));
+  // Faint white ray traversing the glass.
   root.addChild(
-    new Line(-92, -10, -34, 8, {
-      stroke: INTRO_WHITE_RAY_STROKE,
-      lineWidth: INTRO_WHITE_RAY_LINE_WIDTH,
-      lineCap: "round",
-    }),
+    new Line(entry.x, entry.y, exit.x, exit.y, { stroke: "rgba(255,255,235,0.55)", lineWidth: 3, lineCap: "round" }),
   );
 
-  // Dispersed spectrum exiting the right face
-  for (const [yEnd, color] of INTRO_SPECTRUM) {
+  // Dispersed spectrum exiting the right face: violet deviates most (largest downward angle).
+  for (let i = 0; i < SPECTRUM_WL.length; i++) {
+    const endY = 56 - 7 * i; // violet (i=0) → 56, red (i=last) → 14
     root.addChild(
-      new Line(INTRO_SPECTRUM_EXIT_X, INTRO_SPECTRUM_EXIT_Y, 92, yEnd, {
-        stroke: color,
-        lineWidth: INTRO_SPECTRUM_LINE_WIDTH,
+      new Line(exit.x, exit.y, 94, endY, {
+        stroke: wlColor(SPECTRUM_WL[i] ?? 555),
+        lineWidth: 3.4,
         lineCap: "round",
       }),
     );
@@ -128,107 +89,105 @@ function wrapIntroIcon(): Node {
   return root;
 }
 
-// ── Lab: optical bench with point source, biconvex lens, detector screen ──────
+// ── Lab: optical bench imaging a point source through a lens onto a detector ───
+// A point source emits diverging rays; the biconvex lens collects and converges them
+// to a focal spot on the detector screen.
 function wrapLabIcon(): Node {
   const root = new Node();
 
-  // Bench rail
+  const source = { x: -80, y: 0 };
+  const focus = { x: 64, y: 0 };
+  const railY = 54;
+  const lensHalfHeight = 30;
+  // Heights at which each ray crosses the (thin) lens plane at x = 0.
+  const rayHeights = [-26, -13, 0, 13, 26];
+
+  // Bench rail with tick marks.
   root.addChild(
-    new Line(-96, 44, 96, 44, {
-      stroke: LAB_BENCH_STROKE,
-      lineWidth: LAB_BENCH_LINE_WIDTH,
-      lineCap: "round",
-    }),
+    new Line(-96, railY, 96, railY, { stroke: "rgba(135, 150, 182, 0.9)", lineWidth: 7, lineCap: "round" }),
   );
-  // Tick marks
-  for (const x of LAB_TICK_X_POSITIONS) {
-    root.addChild(
-      new Line(x, 40, x, 48, {
-        stroke: LAB_TICK_STROKE,
-        lineWidth: LAB_TICK_LINE_WIDTH,
-      }),
-    );
+  for (const x of [-72, -48, -24, 0, 24, 48, 72]) {
+    root.addChild(new Line(x, railY - 4, x, railY + 4, { stroke: "rgba(85, 98, 128, 0.85)", lineWidth: 1.5 }));
   }
 
-  // Point source with three glow rings
-  root.addChild(
-    new Path(Shape.circle(LAB_SOURCE_X, LAB_SOURCE_Y, 10), {
-      fill: ACCENT,
-      stroke: LAB_SOURCE_GLOW_STROKE,
-      lineWidth: 2.5,
-    }),
-  );
-  root.addChild(
-    new Path(Shape.circle(LAB_SOURCE_X, LAB_SOURCE_Y, 19), {
-      fill: null,
-      stroke: LAB_SOURCE_RING1_STROKE,
-      lineWidth: 2,
-    }),
-  );
-  root.addChild(
-    new Path(Shape.circle(LAB_SOURCE_X, LAB_SOURCE_Y, 29), {
-      fill: null,
-      stroke: LAB_SOURCE_RING2_STROKE,
-      lineWidth: 1.5,
-    }),
-  );
-  // Source stand
-  root.addChild(
-    new Line(LAB_SOURCE_X, 24, LAB_SOURCE_X, 44, {
-      stroke: LAB_STAND_STROKE,
-      lineWidth: 3,
-      lineCap: "round",
-    }),
-  );
-
-  // Biconvex lens centered at x = 0
-  root.addChild(
-    new Path(new Shape().moveTo(0, -38).quadraticCurveTo(22, 4, 0, 44).quadraticCurveTo(-22, 4, 0, -38).close(), {
-      fill: LENS_FILL,
-      stroke: LENS_STROKE,
-      lineWidth: 3,
-    }),
-  );
-
-  // Flat detector screen on the right
-  root.addChild(
-    new Path(Shape.roundRect(LAB_DETECTOR_X, -24, 9, 68, 3, 3), {
-      fill: LAB_DETECTOR_FILL,
-      stroke: LAB_DETECTOR_STROKE,
-      lineWidth: 2.5,
-    }),
-  );
-  // Bright focal spot on screen
-  root.addChild(
-    new Path(Shape.circle(LAB_DETECTOR_X, LAB_FOCAL_SPOT_Y, 7), {
-      fill: RAY,
-      stroke: LAB_FOCAL_SPOT_STROKE,
-      lineWidth: 2.5,
-    }),
-  );
-
-  // Three rays: source → lens → detector (all converging to focal spot)
-  for (const [y0, yMid, color] of LAB_RAY_ROWS) {
-    root.addChild(new Line(-68, y0, -11, y0, { stroke: color, lineWidth: 2.6, lineCap: "round" }));
-    root.addChild(new Line(-11, y0, 11, yMid, { stroke: color, lineWidth: 2.6, lineCap: "round" }));
+  // Rays: diverging from the source to the lens, then converging to the focal spot.
+  for (const yLens of rayHeights) {
+    const isAxis = yLens === 0;
     root.addChild(
-      new Line(11, yMid, LAB_DETECTOR_X, LAB_FOCAL_SPOT_Y, {
-        stroke: color.replace("1.0)", "0.75)").replace("0.85)", "0.62)").replace("0.7)", "0.5)"),
-        lineWidth: 2.3,
+      new Line(source.x, source.y, 0, yLens, {
+        stroke: isAxis ? RAY : RAY_SOFT,
+        lineWidth: isAxis ? 2.6 : 2.2,
+        lineCap: "round",
+      }),
+    );
+    root.addChild(
+      new Line(0, yLens, focus.x, focus.y, {
+        stroke: isAxis ? RAY : "rgba(85, 238, 119, 0.6)",
+        lineWidth: isAxis ? 2.4 : 2.0,
         lineCap: "round",
       }),
     );
   }
 
+  // Element stands rising from the rail.
+  root.addChild(
+    new Line(source.x, source.y + 10, source.x, railY, {
+      stroke: "rgba(108, 124, 158, 0.85)",
+      lineWidth: 3,
+      lineCap: "round",
+    }),
+  );
+  root.addChild(
+    new Line(0, lensHalfHeight, 0, railY, { stroke: "rgba(108, 124, 158, 0.85)", lineWidth: 3, lineCap: "round" }),
+  );
+  root.addChild(
+    new Line(focus.x, 28, focus.x, railY, { stroke: "rgba(108, 124, 158, 0.85)", lineWidth: 3, lineCap: "round" }),
+  );
+
+  // Biconvex lens at x = 0.
+  root.addChild(
+    new Path(
+      new Shape()
+        .moveTo(0, -lensHalfHeight)
+        .quadraticCurveTo(20, 0, 0, lensHalfHeight)
+        .quadraticCurveTo(-20, 0, 0, -lensHalfHeight)
+        .close(),
+      { fill: LENS_FILL, stroke: LENS_STROKE, lineWidth: 3 },
+    ),
+  );
+
+  // Point source: bright core with glow rings.
+  root.addChild(
+    new Path(Shape.circle(source.x, source.y, 10), { fill: ACCENT, stroke: "rgba(255, 195, 85, 0.9)", lineWidth: 2.5 }),
+  );
+  root.addChild(
+    new Path(Shape.circle(source.x, source.y, 18), { fill: null, stroke: "rgba(255, 190, 80, 0.35)", lineWidth: 2 }),
+  );
+  root.addChild(
+    new Path(Shape.circle(source.x, source.y, 27), { fill: null, stroke: "rgba(255, 185, 75, 0.15)", lineWidth: 1.5 }),
+  );
+
+  // Detector screen with the bright focal spot.
+  root.addChild(
+    new Path(Shape.roundRect(focus.x - 4, -28, 9, 56, 3, 3), {
+      fill: "rgba(75, 90, 122, 0.4)",
+      stroke: "rgba(152, 168, 205, 0.9)",
+      lineWidth: 2.5,
+    }),
+  );
+  root.addChild(
+    new Path(Shape.circle(focus.x, focus.y, 7), { fill: RAY, stroke: "rgba(85, 238, 119, 0.5)", lineWidth: 2.5 }),
+  );
+
   return root;
 }
 
-// ── Presets: three cards, each showing a distinct optical setup ────────────────
+// ── Presets: three cards, each a recognizable optical instrument ───────────────
 function wrapPresetsIcon(): Node {
   const root = new Node();
 
-  // Card backgrounds
-  for (const y of PRESET_CARD_Y_CENTERS) {
+  const cardYCenters = [-36, 0, 36] as const;
+  for (const y of cardYCenters) {
     root.addChild(
       new Path(Shape.roundRect(-80, y - 16, 160, 28, 8, 8), {
         fill: PRESET_ROW,
@@ -238,12 +197,12 @@ function wrapPresetsIcon(): Node {
     );
   }
 
-  const [y0card, y1card, y2card] = PRESET_CARD_Y_CENTERS;
+  const [y0card, y1card, y2card] = cardYCenters;
 
-  // ── Card 1 (y=-36): refracting telescope — two lenses, parallel-in parallel-out ──
+  // ── Card 1: refracting telescope — parallel in, parallel out (afocal). ──
   {
     const y = y0card;
-    // Objective lens (left, larger)
+    // Objective lens (left, larger).
     root.addChild(
       new Path(
         new Shape()
@@ -254,7 +213,7 @@ function wrapPresetsIcon(): Node {
         { fill: LENS_FILL, stroke: LENS_STROKE, lineWidth: 1.8 },
       ),
     );
-    // Eyepiece lens (right, smaller)
+    // Eyepiece lens (right, smaller).
     root.addChild(
       new Path(
         new Shape()
@@ -265,17 +224,15 @@ function wrapPresetsIcon(): Node {
         { fill: LENS_FILL, stroke: LENS_STROKE, lineWidth: 1.8 },
       ),
     );
-    // Parallel input rays (3)
     for (const dy of [-7, 0, 7]) {
       root.addChild(
         new Line(-80, y + dy, -67, y + dy, { stroke: dy === 0 ? RAY : RAY_SOFT, lineWidth: 1.8, lineCap: "round" }),
       );
     }
-    // Converging between lenses
+    // Converging to the shared focal plane between the lenses.
     root.addChild(new Line(-49, y - 7, -18, y - 2, { stroke: RAY_SOFT, lineWidth: 1.6, lineCap: "round" }));
     root.addChild(new Line(-49, y, -18, y, { stroke: RAY, lineWidth: 1.8, lineCap: "round" }));
     root.addChild(new Line(-49, y + 7, -18, y + 2, { stroke: RAY_SOFT, lineWidth: 1.6, lineCap: "round" }));
-    // Parallel output rays after eyepiece
     for (const dy of [-5, 0, 5]) {
       root.addChild(
         new Line(-6, y + dy, 72, y + dy, { stroke: dy === 0 ? RAY : RAY_SOFT, lineWidth: 1.6, lineCap: "round" }),
@@ -283,10 +240,9 @@ function wrapPresetsIcon(): Node {
     }
   }
 
-  // ── Card 2 (y=0): reflecting telescope — parallel rays + parabolic mirror ──
+  // ── Card 2: reflecting telescope — parallel rays focused by a concave mirror. ──
   {
     const y = y1card;
-    // Parabolic mirror (concave, on right)
     root.addChild(
       new Path(new Shape().moveTo(46, y - 14).quadraticCurveTo(62, y, 46, y + 14), {
         stroke: MIRROR,
@@ -295,28 +251,18 @@ function wrapPresetsIcon(): Node {
         fill: null,
       }),
     );
-    // Parallel incident rays
     root.addChild(new Line(-80, y - 7, 40, y - 7, { stroke: RAY_SOFT, lineWidth: 1.8, lineCap: "round" }));
     root.addChild(new Line(-80, y, 40, y, { stroke: RAY, lineWidth: 2, lineCap: "round" }));
     root.addChild(new Line(-80, y + 7, 40, y + 7, { stroke: RAY_SOFT, lineWidth: 1.8, lineCap: "round" }));
-    // Reflected rays converging to focal point
     root.addChild(new Line(40, y - 7, 24, y, { stroke: RAY_SOFT, lineWidth: 1.8, lineCap: "round" }));
     root.addChild(new Line(40, y, 24, y, { stroke: RAY, lineWidth: 2, lineCap: "round" }));
     root.addChild(new Line(40, y + 7, 24, y, { stroke: RAY_SOFT, lineWidth: 1.8, lineCap: "round" }));
-    // Focal point
-    root.addChild(
-      new Path(Shape.circle(24, y, 5), {
-        fill: ACCENT,
-        stroke: PRESET_FOCAL_GLOW_STROKE,
-        lineWidth: 2,
-      }),
-    );
+    root.addChild(new Path(Shape.circle(24, y, 5), { fill: ACCENT, stroke: "rgba(255, 195, 85, 0.6)", lineWidth: 2 }));
   }
 
-  // ── Card 3 (y=+36): spectroscope — prism dispersing to spectrum ──
+  // ── Card 3: spectroscope — prism dispersing to a spectrum (violet deviates most). ──
   {
     const y = y2card;
-    // Mini prism
     root.addChild(
       new Path(
         new Shape()
@@ -325,28 +271,17 @@ function wrapPresetsIcon(): Node {
           .lineTo(-22, y + 12)
           .close(),
         {
-          fill: PRESET_MINI_PRISM_FILL,
-          stroke: PRESET_MINI_PRISM_STROKE,
+          fill: GLASS_FILL,
+          stroke: "rgba(155, 195, 238, 0.75)",
           lineWidth: 1.8,
         },
       ),
     );
-    // Incoming white ray
-    root.addChild(
-      new Line(-80, y, -54, y + 6, {
-        stroke: PRESET_WHITE_RAY_STROKE,
-        lineWidth: 2.5,
-        lineCap: "round",
-      }),
-    );
-    // Spectrum fan
-    for (const [yEnd, color] of PRESET_SPECTRUM) {
+    root.addChild(new Line(-80, y, -54, y + 6, { stroke: WHITE_RAY, lineWidth: 2.5, lineCap: "round" }));
+    for (let i = 0; i < SPECTRUM_WL.length; i++) {
+      const endY = y + 20 - 5 * i; // violet most deviation (largest downward angle)
       root.addChild(
-        new Line(-22, y + 8, 72, y + yEnd, {
-          stroke: color,
-          lineWidth: 2,
-          lineCap: "round",
-        }),
+        new Line(-22, y + 8, 72, endY, { stroke: wlColor(SPECTRUM_WL[i] ?? 555), lineWidth: 2, lineCap: "round" }),
       );
     }
   }
@@ -354,31 +289,53 @@ function wrapPresetsIcon(): Node {
   return root;
 }
 
-// ── Diffraction: grating with incoming beam and fanned orders ─────────────────
+// ── Diffraction: grating with a zeroth order plus symmetric, dispersed orders ──
+// Unlike a prism, a grating spreads each order so that red (long wavelength) deviates
+// most. The undeviated zeroth order passes straight through; higher orders appear
+// symmetrically above and below, and second orders exist only for the shorter
+// wavelengths whose diffraction angle stays below 90°.
 function wrapDiffractionIcon(): Node {
   const root = new Node();
+
+  // Ruled grating: a stack of fine vertical lines.
   for (let i = -3; i <= 3; i++) {
-    const x = i * DIFFRACTION_GRATING_SPACING;
-    root.addChild(
-      new Line(x, DIFFRACTION_GRATING_Y0, x, DIFFRACTION_GRATING_Y1, {
-        stroke: DIFFRACTION_GRATING_STROKE,
-        lineWidth: DIFFRACTION_GRATING_LINE_WIDTH,
-        lineCap: "round",
-      }),
-    );
+    const x = i * 7;
+    root.addChild(new Line(x, -46, x, 46, { stroke: "rgba(200, 210, 230, 0.85)", lineWidth: 3, lineCap: "round" }));
   }
-  // Incoming beam
-  root.addChild(new Line(-95, 0, -38, 0, { stroke: RAY, lineWidth: 3, lineCap: "round" }));
-  // Diffracted orders (fan)
-  for (const { a, c } of DIFFRACTION_ORDERS) {
-    root.addChild(
-      new Line(38, 0, 38 + DIFFRACTION_FAN_LENGTH * Math.cos(a), -DIFFRACTION_FAN_LENGTH * Math.sin(a), {
-        stroke: c,
-        lineWidth: 2.4,
-        lineCap: "round",
-      }),
-    );
+
+  const origin = { x: 20, y: 0 };
+
+  // Incoming collimated white beam and the undeviated zeroth order.
+  root.addChild(new Line(-94, 0, -20, 0, { stroke: WHITE_RAY, lineWidth: 4, lineCap: "round" }));
+  root.addChild(new Line(origin.x, 0, 94, 0, { stroke: WHITE_RAY, lineWidth: 3.5, lineCap: "round" }));
+
+  // First-order spectra, fanned symmetrically; violet nearest the axis, red farthest.
+  const firstOrderLen = 82;
+  for (let i = 0; i < SPECTRUM_WL.length; i++) {
+    const angle = ((15 + 5 * i) * Math.PI) / 180; // violet ~15°, red ~45°
+    const dx = firstOrderLen * Math.cos(angle);
+    const dy = firstOrderLen * Math.sin(angle);
+    const color = wlColor(SPECTRUM_WL[i] ?? 555);
+    root.addChild(new Line(origin.x, 0, origin.x + dx, -dy, { stroke: color, lineWidth: 2.6, lineCap: "round" }));
+    root.addChild(new Line(origin.x, 0, origin.x + dx, dy, { stroke: color, lineWidth: 2.6, lineCap: "round" }));
   }
+
+  // Faint second-order partial spectra: only the shorter wavelengths diffract within range.
+  const secondOrderLen = 58;
+  for (let i = 0; i < 3; i++) {
+    const sinTheta1 = Math.sin(((15 + 5 * i) * Math.PI) / 180);
+    const sinTheta2 = 2 * sinTheta1;
+    if (sinTheta2 >= 1) {
+      continue;
+    }
+    const angle = Math.asin(sinTheta2);
+    const dx = secondOrderLen * Math.cos(angle);
+    const dy = secondOrderLen * Math.sin(angle);
+    const color = wlColor(SPECTRUM_WL[i] ?? 555, 0.65);
+    root.addChild(new Line(origin.x, 0, origin.x + dx, -dy, { stroke: color, lineWidth: 1.8, lineCap: "round" }));
+    root.addChild(new Line(origin.x, 0, origin.x + dx, dy, { stroke: color, lineWidth: 1.8, lineCap: "round" }));
+  }
+
   return root;
 }
 


### PR DESCRIPTION
Rework the four home/navbar icons so each is a physically faithful
miniature of its screen, and source spectrum colors from
VisibleColor.wavelengthToColor (matching the sim's ray rendering)
instead of hand-picked hex.

- Intro (prism): draw the internal ray through the glass and disperse
  the spectrum in one direction toward the base, with violet deviating
  most and red least (was symmetric and reversed).
- Lab (bench): emit diverging rays from the point source that the lens
  converges to a focal spot on the detector (rays were parallel before
  the lens, which implies a source at infinity).
- Diffraction (grating): show the undeviated zeroth order plus symmetric
  first orders dispersed with red deviating most, and faint partial
  second orders that vanish past 90 deg (was a one-sided prism-like fan).
- Presets: align the spectroscope card's dispersion direction and use
  the shared accurate spectrum.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PKMyv5jaKW8gd5S4C4mN1b