### PR TITLE
Fix four model-layer bugs found in code review

### DIFF
--- a/src/common/model/detectors/DetectorElement.ts
+++ b/src/common/model/detectors/DetectorElement.ts
@@ -13,6 +13,7 @@ import { DETECTOR_NUM_BINS } from "../../../OpticsLabConstants.js";
 import { ELEMENT_CATEGORY_BLOCKER, ELEMENT_TYPE_DETECTOR } from "../../../OpticsLabStrings.js";
 import { BaseSegmentElement } from "../optics/BaseSegmentElement.js";
 import {
+  arcBounds,
   type Bounds,
   circle,
   circumcenter,
@@ -22,7 +23,6 @@ import {
   normalize,
   type Point,
   point,
-  pointsBounds,
   rayCircleIntersections,
   subtract,
 } from "../optics/Geometry.js";
@@ -133,7 +133,9 @@ export class DetectorElement extends BaseSegmentElement implements IAcquirable {
   }
 
   public override getBounds(): Bounds {
-    return pointsBounds([this.p1, this.p2, this.p3]);
+    // Arc-aware bounds so the spatial index never culls rays that hit the
+    // curved detector's bulge outside the p1/p2/p3 box.
+    return arcBounds(this.p1, this.p2, this.p3);
   }
 
   public override checkRayIntersection(ray: SimulationRay): IntersectionResult | null {

--- a/src/common/model/glass/Glass.ts
+++ b/src/common/model/glass/Glass.ts
@@ -16,6 +16,7 @@
 
 import { ELEMENT_TYPE_GLASS } from "../../../OpticsLabStrings.js";
 import {
+  arcBounds,
   type Bounds,
   circle,
   distance,
@@ -82,7 +83,25 @@ export class Glass extends BaseGlass {
   // ── Bounding box ─────────────────────────────────────────────────────────
 
   public getBounds(): Bounds {
-    return pointsBounds(this.path);
+    const bounds = pointsBounds(this.path);
+    // Extend for arc edges: an arc bulges beyond the box of its three defining
+    // points, and an underestimated box would let the spatial index cull rays
+    // that actually hit the surface.
+    let { minX, minY, maxX, maxY } = bounds;
+    const n = this.path.length;
+    for (let i = 0; i < n; i++) {
+      const current = this.path[i % n] as GlassPathPoint;
+      const next = this.path[(i + 1) % n] as GlassPathPoint;
+      if (next.arc && !current.arc) {
+        const after = this.path[(i + 2) % n] as GlassPathPoint;
+        const ab = arcBounds(point(current.x, current.y), point(after.x, after.y), point(next.x, next.y));
+        minX = Math.min(minX, ab.minX);
+        minY = Math.min(minY, ab.minY);
+        maxX = Math.max(maxX, ab.maxX);
+        maxY = Math.max(maxY, ab.maxY);
+      }
+    }
+    return { minX, minY, maxX, maxY };
   }
 
   // ── Ray intersection ─────────────────────────────────────────────────────

--- a/src/common/model/glass/IdealLens.ts
+++ b/src/common/model/glass/IdealLens.ts
@@ -93,10 +93,15 @@ export class IdealLens extends BaseSegmentElement {
     const ipY = intersection.point.y - center.y;
     const h = ipX * parX + ipY * parY;
 
-    // Thin lens deflection: the ray is deflected so that its parallel
-    // slope changes by -h/f while perpendicular component is preserved
+    // Thin lens deflection: the ray is deflected so that its slope with
+    // respect to the propagation direction changes by -h/f while the
+    // perpendicular component is preserved. slopeIn/slopeOut are par/per
+    // ratios with a *signed* per component, so the -h/f kick must flip sign
+    // for rays traveling against the lens normal (rayDirPer < 0) — otherwise
+    // a converging lens acts as a diverging lens for rays incident from the
+    // back side.
     const slopeIn = rayDirPar / rayDirPer;
-    const slopeOut = slopeIn - h / this.focalLength;
+    const slopeOut = slopeIn - (h / this.focalLength) * Math.sign(rayDirPer);
 
     // Reconstruct direction: per component keeps its sign
     const outDirPer = Math.sign(rayDirPer);

--- a/src/common/model/light-sources/BeamSource.ts
+++ b/src/common/model/light-sources/BeamSource.ts
@@ -48,12 +48,17 @@ export class BeamSource extends BaseLightSource {
 
     const rays: SimulationRay[] = [];
 
+    let idx = 0;
     for (let i = 0.5; i <= n; i++) {
       const jitterFrac = jitter ? Math.random() - 0.5 : 0;
       const x = this.p1.x + (i + jitterFrac) * stepX;
       const y = this.p1.y + (i + jitterFrac) * stepY;
       const dir = normalize(subtract(point(x + Math.sin(normal), y + Math.cos(normal)), point(x, y)));
-      rays.push(this.makeRay(point(x, y), dir, b, i === 0.5));
+      // sourceId/rayIndex let the tracer group this beam's rays separately from
+      // other sources during image detection (rays without a sourceId all pool
+      // into one shared group, producing spurious cross-source image markers).
+      rays.push(this.makeRay(point(x, y), dir, b, i === 0.5, this.id, idx));
+      idx++;
     }
 
     return rays;

--- a/src/common/model/light-sources/ContinuousSpectrumSource.ts
+++ b/src/common/model/light-sources/ContinuousSpectrumSource.ts
@@ -85,6 +85,7 @@ export class ContinuousSpectrumSource extends BaseLightSource {
 
     const rays: SimulationRay[] = [];
     let first = true;
+    let idx = 0;
     for (const wavelength of wavelengths) {
       rays.push({
         origin: point(this.p1.x, this.p1.y),
@@ -95,8 +96,11 @@ export class ContinuousSpectrumSource extends BaseLightSource {
         isNew: true,
         wavelength,
         spectrumAdditiveBlend: true,
+        sourceId: this.id,
+        rayIndex: idx,
       });
       first = false;
+      idx++;
     }
 
     return rays;

--- a/src/common/model/light-sources/DivergentBeam.ts
+++ b/src/common/model/light-sources/DivergentBeam.ts
@@ -68,27 +68,39 @@ export class DivergentBeam extends BaseLightSource {
 
     const rays: SimulationRay[] = [];
 
+    // sourceId/rayIndex let the tracer group this beam's rays separately from
+    // other sources during image detection (rays without a sourceId all pool
+    // into one shared group, producing spurious cross-source image markers).
+    let idx = 0;
     for (let i = 0.5; i <= n; i++) {
       const jitterFrac = jitter ? Math.random() - 0.5 : 0;
       const x = this.p1.x + (i + jitterFrac) * stepX;
       const y = this.p1.y + (i + jitterFrac) * stepY;
 
-      rays.push(this.createRay(x, y, normal, 0, i === 0.5, b));
+      rays.push(this.createRay(x, y, normal, 0, i === 0.5, b, idx++));
 
       for (let angle = angularStep; angle < halfAngle; angle += angularStep) {
-        rays.push(this.createRay(x, y, normal, angle, false, b));
-        rays.push(this.createRay(x, y, normal, -angle, false, b));
+        rays.push(this.createRay(x, y, normal, angle, false, b, idx++));
+        rays.push(this.createRay(x, y, normal, -angle, false, b, idx++));
       }
     }
 
     return rays;
   }
 
-  private createRay(x: number, y: number, normalAngle: number, angle: number, gap: boolean, b: number): SimulationRay {
+  private createRay(
+    x: number,
+    y: number,
+    normalAngle: number,
+    angle: number,
+    gap: boolean,
+    b: number,
+    rayIndex: number,
+  ): SimulationRay {
     const dir = normalize(
       subtract(point(x + Math.sin(normalAngle + angle), y + Math.cos(normalAngle + angle)), point(x, y)),
     );
-    return this.makeRay(point(x, y), dir, b, gap);
+    return this.makeRay(point(x, y), dir, b, gap, this.id, rayIndex);
   }
 
   public serialize(): Record<string, unknown> {

--- a/src/common/model/light-sources/SingleRaySource.ts
+++ b/src/common/model/light-sources/SingleRaySource.ts
@@ -30,7 +30,7 @@ export class SingleRaySource extends BaseLightSource {
 
   public override emitRays(_rayDensity: number, _mode: ViewMode): SimulationRay[] {
     const dir = normalize(subtract(this.p2, this.p1));
-    return [this.makeRay(point(this.p1.x, this.p1.y), dir, this.brightness, true)];
+    return [this.makeRay(point(this.p1.x, this.p1.y), dir, this.brightness, true, this.id, 0)];
   }
 
   public serialize(): Record<string, unknown> {

--- a/src/common/model/mirrors/ArcMirror.ts
+++ b/src/common/model/mirrors/ArcMirror.ts
@@ -10,6 +10,7 @@
 import { ELEMENT_CATEGORY_MIRROR, ELEMENT_TYPE_ARC_MIRROR } from "../../../OpticsLabStrings.js";
 import { BaseElement } from "../optics/BaseElement.js";
 import {
+  arcBounds,
   type Bounds,
   circle,
   circumcenter,
@@ -19,7 +20,6 @@ import {
   normalize,
   type Point,
   point,
-  pointsBounds,
   rayCircleIntersections,
   subtract,
 } from "../optics/Geometry.js";
@@ -87,7 +87,10 @@ export class ArcMirror extends BaseElement {
   }
 
   public getBounds(): Bounds {
-    return pointsBounds([this.p1, this.p2, this.p3]);
+    // Arc-aware bounds: the arc bulges beyond the box of p1/p2/p3 (dramatically
+    // for arcs spanning more than 180°), and an underestimated box would let
+    // the spatial index cull rays that actually hit the mirror.
+    return arcBounds(this.p1, this.p2, this.p3);
   }
 
   private getArcGeometry(): { center: Point; radius: number } | null {

--- a/src/common/model/optics/Geometry.ts
+++ b/src/common/model/optics/Geometry.ts
@@ -455,6 +455,48 @@ export function pointsBounds(points: readonly Point[]): Bounds {
   return { minX, minY, maxX, maxY };
 }
 
+/**
+ * Compute the AABB of a circular arc from p1 to p2 passing through p3.
+ * Unlike pointsBounds([p1, p2, p3]), this includes the axis-extreme points
+ * of the circle that lie on the arc, so the box fully encloses the bulge
+ * (essential for spatial-index culling — an underestimated box lets rays
+ * pass through the element without being tested).
+ * Falls back to the bounding box of the three points when they are collinear.
+ */
+export function arcBounds(p1: Point, p2: Point, p3: Point): Bounds {
+  const bounds = pointsBounds([p1, p2, p3]);
+  const cc = circumcenter(p1, p2, p3);
+  if (!cc) {
+    return bounds;
+  }
+  const { center, radius } = cc;
+
+  // A point q on the circle lies on the p1→p3→p2 arc iff q is on the same
+  // side of the chord p1–p2 as p3 (same test as Glass.isHitOnArc).
+  const chordDx = p2.x - p1.x;
+  const chordDy = p2.y - p1.y;
+  const sideP3 = chordDx * (p3.y - p1.y) - chordDy * (p3.x - p1.x);
+
+  const extremes: Point[] = [
+    point(center.x + radius, center.y),
+    point(center.x - radius, center.y),
+    point(center.x, center.y + radius),
+    point(center.x, center.y - radius),
+  ];
+  let { minX, minY, maxX, maxY } = bounds;
+  for (const q of extremes) {
+    const sideQ = chordDx * (q.y - p1.y) - chordDy * (q.x - p1.x);
+    // Boundary cases (sideQ ≈ 0) are included — a slight overestimate is harmless.
+    if (Math.sign(sideQ) === Math.sign(sideP3) || sideQ === 0) {
+      minX = Math.min(minX, q.x);
+      minY = Math.min(minY, q.y);
+      maxX = Math.max(maxX, q.x);
+      maxY = Math.max(maxY, q.y);
+    }
+  }
+  return { minX, minY, maxX, maxY };
+}
+
 // ── Fresnel Equations ────────────────────────────────────────────────────────
 
 /**

--- a/src/common/model/optics/elementSerialization.ts
+++ b/src/common/model/optics/elementSerialization.ts
@@ -12,10 +12,13 @@
 import { ARCHETYPE_DEFAULT_WAVELENGTH_NM, DEFAULT_BEAM_BRIGHTNESS } from "../../../OpticsLabConstants.js";
 import {
   ELEMENT_TYPE_APERTURE,
+  ELEMENT_TYPE_APERTURED_PARABOLIC_MIRROR,
   ELEMENT_TYPE_ARC_MIRROR,
   ELEMENT_TYPE_ARC_SOURCE,
   ELEMENT_TYPE_BEAM,
   ELEMENT_TYPE_BEAM_SPLITTER,
+  ELEMENT_TYPE_BICONCAVE_LENS,
+  ELEMENT_TYPE_BICONVEX_LENS,
   ELEMENT_TYPE_CIRCLE_GLASS,
   ELEMENT_TYPE_CONTINUOUS_SPECTRUM_SOURCE,
   ELEMENT_TYPE_DETECTOR,
@@ -30,6 +33,8 @@ import {
   ELEMENT_TYPE_PARABOLIC_MIRROR,
   ELEMENT_TYPE_PARALLELOGRAM_PRISM,
   ELEMENT_TYPE_PLANE_GLASS,
+  ELEMENT_TYPE_PLANO_CONCAVE_LENS,
+  ELEMENT_TYPE_PLANO_CONVEX_LENS,
   ELEMENT_TYPE_POINT_SOURCE,
   ELEMENT_TYPE_PORRO_PRISM,
   ELEMENT_TYPE_REFLECTION_GRATING,
@@ -45,6 +50,8 @@ import { ApertureElement } from "../blockers/ApertureElement.js";
 import { LineBlocker } from "../blockers/LineBlocker.js";
 import { DetectorElement } from "../detectors/DetectorElement.js";
 import { FiberOpticElement } from "../fiber/FiberOpticElement.js";
+import { BiconcaveLens } from "../glass/BiconcaveLens.js";
+import { BiconvexLens } from "../glass/BiconvexLens.js";
 import { CircleGlass } from "../glass/CircleGlass.js";
 import { DovePrism } from "../glass/DovePrism.js";
 import { EquilateralPrism } from "../glass/EquilateralPrism.js";
@@ -53,6 +60,8 @@ import { Glass } from "../glass/Glass.js";
 import { HalfPlaneGlass } from "../glass/HalfPlaneGlass.js";
 import { IdealLens } from "../glass/IdealLens.js";
 import { ParallelogramPrism } from "../glass/ParallelogramPrism.js";
+import { PlanoConcaveLens } from "../glass/PlanoConcaveLens.js";
+import { PlanoConvexLens } from "../glass/PlanoConvexLens.js";
 import { PorroPrism } from "../glass/PorroPrism.js";
 import { RightAnglePrism } from "../glass/RightAnglePrism.js";
 import { SlabGlass } from "../glass/SlabGlass.js";
@@ -66,6 +75,7 @@ import { ContinuousSpectrumSource } from "../light-sources/ContinuousSpectrumSou
 import { DivergentBeam } from "../light-sources/DivergentBeam.js";
 import { PointSourceElement } from "../light-sources/PointSourceElement.js";
 import { SingleRaySource } from "../light-sources/SingleRaySource.js";
+import { AperturedParabolicMirror } from "../mirrors/AperturedParabolicMirror.js";
 import { ArcMirror } from "../mirrors/ArcMirror.js";
 import { BeamSplitterElement } from "../mirrors/BeamSplitterElement.js";
 import { IdealCurvedMirror } from "../mirrors/IdealCurvedMirror.js";
@@ -116,6 +126,25 @@ function asNumber(v: unknown, field: string, min?: number, max?: number): number
   }
   if (max !== undefined && v > max) {
     throw new Error(`Value at field "${field}" (${v}) exceeds maximum ${max}`);
+  }
+  return v;
+}
+
+/**
+ * Parse a radius-of-curvature field. Flat surfaces are represented as
+ * ±Infinity in the model, which JSON.stringify serializes as null — so
+ * null/undefined and non-finite numbers are all restored as Infinity.
+ * A zero radius is invalid (degenerate surface).
+ */
+function asRadius(v: unknown, field: string): number {
+  if (v === null || v === undefined) {
+    return Infinity;
+  }
+  if (typeof v !== "number" || Number.isNaN(v)) {
+    throw new Error(`Invalid radius at field "${field}": ${JSON.stringify(v)}`);
+  }
+  if (v === 0) {
+    throw new Error(`Radius at field "${field}" must not be zero`);
   }
   return v;
 }
@@ -270,6 +299,16 @@ const DEFS: Record<string, ElementDef> = {
     fields: [p("p1"), p("p2"), n("transRatio", 0, 1)],
     build: (v) => new BeamSplitterElement(v["p1"] as Point, v["p2"] as Point, v["transRatio"] as number),
   },
+  [ELEMENT_TYPE_APERTURED_PARABOLIC_MIRROR]: {
+    fields: [p("p1"), p("p2"), p("p3"), n("apertureHalfWidth", 0)],
+    build: (v) =>
+      new AperturedParabolicMirror(
+        v["p1"] as Point,
+        v["p2"] as Point,
+        v["p3"] as Point,
+        v["apertureHalfWidth"] as number,
+      ),
+  },
 
   // ── Prisms & glass ───────────────────────────────────────────────────────
   [ELEMENT_TYPE_EQUILATERAL_PRISM]: {
@@ -401,17 +440,33 @@ export function deserializeElement(obj: Record<string, unknown>): OpticalElement
       assignElementId(el, obj["id"]);
       return el;
     }
-    case ELEMENT_TYPE_SPHERICAL_LENS: {
-      const r1 = asNumber(obj["r1"], "r1");
-      const r2 = asNumber(obj["r2"], "r2");
+    case ELEMENT_TYPE_SPHERICAL_LENS:
+    case ELEMENT_TYPE_BICONVEX_LENS:
+    case ELEMENT_TYPE_BICONCAVE_LENS:
+    case ELEMENT_TYPE_PLANO_CONVEX_LENS:
+    case ELEMENT_TYPE_PLANO_CONCAVE_LENS: {
+      // Radii are parsed with asRadius because flat surfaces serialize
+      // Infinity → null through JSON.
+      const r1 = asRadius(obj["r1"], "r1");
+      const r2 = asRadius(obj["r2"], "r2");
       const d = asNumber(obj["d"], "d", 0);
-      const lens = new SphericalLens(
-        asPoint(obj["p1"], "p1"),
-        asPoint(obj["p2"], "p2"),
-        r1,
-        r2,
-        asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN),
-      );
+      const p1 = asPoint(obj["p1"], "p1");
+      const p2 = asPoint(obj["p2"], "p2");
+      const refIndex = asNumber(obj["refIndex"], "refIndex", REF_INDEX_MIN);
+      let lens: SphericalLens;
+      if (type === ELEMENT_TYPE_BICONVEX_LENS) {
+        lens = new BiconvexLens(p1, p2, Math.abs(r1), refIndex);
+      } else if (type === ELEMENT_TYPE_BICONCAVE_LENS) {
+        lens = new BiconcaveLens(p1, p2, Math.abs(r1), refIndex);
+      } else if (type === ELEMENT_TYPE_PLANO_CONVEX_LENS) {
+        lens = new PlanoConvexLens(p1, p2, Math.abs(r2), refIndex);
+      } else if (type === ELEMENT_TYPE_PLANO_CONCAVE_LENS) {
+        lens = new PlanoConcaveLens(p1, p2, Math.abs(r2), refIndex);
+      } else {
+        lens = new SphericalLens(p1, p2, r1, r2, refIndex);
+      }
+      // Rebuild with the serialized thickness; subclass overrides re-enforce
+      // their own r1/r2 constraints, so passing both radii is safe.
       lens.createLensWithDR1R2(d, r1, r2);
       assignElementId(lens, obj["id"]);
       return lens;

--- a/src/common/view/ViewHelpers.ts
+++ b/src/common/view/ViewHelpers.ts
@@ -225,6 +225,50 @@ export function attachEndpointDrag(
 }
 
 /**
+ * Creates start/end callbacks that record a custom geometry drag as a single
+ * undoable command, for RichDragListeners whose drag logic is too specialized
+ * for attachEndpointDrag/attachTranslationDrag (e.g. lens curvature, prism
+ * scale/rotation).
+ *
+ * `capture` flattens the mutated state into a number array; `restore` applies
+ * such a snapshot back to the model and refreshes the view. The command is
+ * push()ed (not execute()d) because the drag has already applied the final
+ * state when `end` fires.
+ *
+ * Usage:
+ *   const hooks = createDragHistoryHooks("Resize prism", capture, restore);
+ *   new RichDragListener({ start: hooks.start, drag: ..., end: hooks.end });
+ */
+export function createDragHistoryHooks(
+  description: string,
+  capture: () => number[],
+  restore: (values: number[]) => void,
+): { start: () => void; end: () => void } {
+  let before: number[] = [];
+  return {
+    start: () => {
+      before = capture();
+    },
+    end: () => {
+      const history = sceneHistoryRegistry.history;
+      if (!history) {
+        return;
+      }
+      const after = capture();
+      if (before.length === after.length && before.every((v, i) => v === after[i])) {
+        return;
+      }
+      const b = before;
+      history.push({
+        description,
+        execute: () => restore(after),
+        undo: () => restore(b),
+      });
+    },
+  };
+}
+
+/**
  * Creates a filled rectangular Shape centred on the line segment from
  * (vx1,vy1) to (vx2,vy2) in view (pixel) coordinates.  Because it is a
  * closed, filled polygon, Scenery's containsPoint() works correctly for

--- a/src/common/view/glass/GlassView.ts
+++ b/src/common/view/glass/GlassView.ts
@@ -34,10 +34,17 @@ import {
   segment,
 } from "../../model/optics/Geometry.js";
 import { BaseOpticalElementView } from "../BaseOpticalElementView.js";
+import { sceneHistoryRegistry } from "../SceneHistoryRegistry.js";
 import { attachTranslationDrag, type DragHandle, makeEndpointHandle, unlinkHandleVisibility } from "../ViewHelpers.js";
 
 export class GlassView extends BaseOpticalElementView {
   private _bodyDragListener!: RichDragListener;
+  /**
+   * Stable array backing the body drag listener. Contents are refreshed in
+   * place by rebuildHandlesAndDragListener() when the path gains or loses
+   * vertices; the listener itself is created exactly once.
+   */
+  private readonly bodyDragPoints: Array<{ get: () => Point; set: (p: Point) => void }> = [];
   private readonly glassPath: Path;
   private readonly handlesContainer: Node;
   private handles: DragHandle[] = [];
@@ -110,15 +117,6 @@ export class GlassView extends BaseOpticalElementView {
     this.addButtons = [];
     this.handlesContainer.removeAllChildren();
 
-    // Dispose the old body drag listener before replacing it. Removing it from
-    // the input-listener list is not enough: the undisposed RichDragListener
-    // keeps its internal DragListener, KeyboardDragListener, isPressedProperty,
-    // and all their TinyEmitters alive (along with closures that capture `this`).
-    if (this._bodyDragListener) {
-      this.glassPath.removeInputListener(this._bodyDragListener);
-      this._bodyDragListener.dispose();
-    }
-
     this.handleVerts = this.isPrism ? [...this.glass.path] : (this.handleVertsOption ?? []);
     this.handles = this.handleVerts.map((vert, index) => {
       const handle = makeEndpointHandle(
@@ -157,22 +155,34 @@ export class GlassView extends BaseOpticalElementView {
       }
     }
 
-    const allVertPoints = this.glass.path.map((v) => ({
-      get: (): Point => ({ x: v.x, y: v.y }),
-      set: (p: Point): void => {
-        v.x = p.x;
-        v.y = p.y;
-      },
-    }));
-    this._bodyDragListener = attachTranslationDrag(
-      this.glassPath,
-      allVertPoints,
-      () => {
-        this.rebuild();
-      },
-      this.modelViewTransform,
-      this.glassTandem.createTandem("bodyDragListener"),
-    );
+    // Repopulate the stable points array in place rather than recreating the
+    // body drag listener. External observers (RayTracingCommonView) link to
+    // bodyDragListener.isPressedProperty once at view creation — disposing and
+    // recreating the listener here would sever that link, silently breaking
+    // drag-layer reparenting and drop-on-carousel deletion after a vertex
+    // add/remove. attachTranslationDrag reads the array contents afresh on
+    // every drag start, so in-place mutation is safe.
+    this.bodyDragPoints.length = 0;
+    for (const v of this.glass.path) {
+      this.bodyDragPoints.push({
+        get: (): Point => ({ x: v.x, y: v.y }),
+        set: (p: Point): void => {
+          v.x = p.x;
+          v.y = p.y;
+        },
+      });
+    }
+    if (!this._bodyDragListener) {
+      this._bodyDragListener = attachTranslationDrag(
+        this.glassPath,
+        this.bodyDragPoints,
+        () => {
+          this.rebuild();
+        },
+        this.modelViewTransform,
+        this.glassTandem.createTandem("bodyDragListener"),
+      );
+    }
   }
 
   private createAddButton(edgeIndex: number): Node {
@@ -212,8 +222,32 @@ export class GlassView extends BaseOpticalElementView {
           const clickMidX = (a.x + b.x) / 2;
           const clickMidY = (a.y + b.y) / 2;
           this.glass.addVertexOnEdge(edgeIndex, { x: clickMidX, y: clickMidY });
-          this.rebuildHandlesAndDragListener();
-          this.rebuild();
+          this.refreshAfterVertexChange();
+
+          // Record as an undoable command (already applied, so push not execute).
+          // The inserted vertex is tracked by object identity so undo/redo stay
+          // correct even after later drags mutate its coordinates.
+          const insertAt = (idx + 1) % len;
+          const inserted = glassPath[insertAt];
+          const history = sceneHistoryRegistry.history;
+          if (history && inserted) {
+            history.push({
+              description: "Add vertex",
+              execute: () => {
+                if (!glassPath.includes(inserted)) {
+                  glassPath.splice(Math.min(insertAt, glassPath.length), 0, inserted);
+                }
+                this.refreshAfterVertexChange();
+              },
+              undo: () => {
+                const insertedIndex = glassPath.indexOf(inserted);
+                if (insertedIndex >= 0) {
+                  this.glass.removeVertex(insertedIndex);
+                }
+                this.refreshAfterVertexChange();
+              },
+            });
+          }
         }
       },
     });
@@ -247,11 +281,43 @@ export class GlassView extends BaseOpticalElementView {
         event.handle();
         const idx = this.glass.path.indexOf(vert);
         if (idx >= 0 && this.glass.removeVertex(idx)) {
-          this.rebuildHandlesAndDragListener();
-          this.rebuild();
+          this.refreshAfterVertexChange();
+
+          // Record as an undoable command (already applied, so push not execute).
+          const history = sceneHistoryRegistry.history;
+          if (history) {
+            history.push({
+              description: "Remove vertex",
+              execute: () => {
+                const i = this.glass.path.indexOf(vert);
+                if (i >= 0) {
+                  this.glass.removeVertex(i);
+                }
+                this.refreshAfterVertexChange();
+              },
+              undo: () => {
+                this.glass.path.splice(Math.min(idx, this.glass.path.length), 0, vert);
+                this.refreshAfterVertexChange();
+              },
+            });
+          }
         }
       },
     });
+  }
+
+  /**
+   * Refresh handles and geometry after the path gained or lost a vertex.
+   * Safe to call from undo/redo commands that may outlive this view: the
+   * model mutation has already happened, so a disposed view just skips the
+   * visual refresh (a fresh view built from the model will be correct).
+   */
+  private refreshAfterVertexChange(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.rebuildHandlesAndDragListener();
+    this.rebuild();
   }
 
   /**

--- a/src/common/view/glass/SphericalLensView.ts
+++ b/src/common/view/glass/SphericalLensView.ts
@@ -33,7 +33,7 @@ import {
 import OpticsLabNamespace from "../../../OpticsLabNamespace.js";
 import type { GlassPathPoint } from "../../model/glass/Glass.js";
 import type { SphericalLens } from "../../model/glass/SphericalLens.js";
-import { buildDiamondShape, createHandle } from "../ViewHelpers.js";
+import { buildDiamondShape, createDragHistoryHooks, createHandle } from "../ViewHelpers.js";
 import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 import { GlassView } from "./GlassView.js";
 
@@ -208,6 +208,40 @@ export class SphericalLensView extends GlassView {
   // Drag wiring
   // ═══════════════════════════════════════════════════════════════════════════
 
+  /** Flatten the lens geometry (6 path points + p1/p2) into a snapshot for undo. */
+  private captureLensState(): number[] {
+    const values: number[] = [];
+    for (const p of this.lens.path) {
+      values.push(p.x, p.y);
+    }
+    values.push(this.lens.p1.x, this.lens.p1.y, this.lens.p2.x, this.lens.p2.y);
+    return values;
+  }
+
+  /** Restore a snapshot produced by captureLensState() and refresh the view. */
+  private restoreLensState(values: number[]): void {
+    const path = this.lens.path;
+    for (let i = 0; i < path.length; i++) {
+      const p = path[i];
+      const x = values[2 * i];
+      const y = values[2 * i + 1];
+      if (p && x !== undefined && y !== undefined) {
+        p.x = x;
+        p.y = y;
+      }
+    }
+    const o = path.length * 2;
+    const p1x = values[o];
+    const p1y = values[o + 1];
+    const p2x = values[o + 2];
+    const p2y = values[o + 3];
+    if (p1x !== undefined && p1y !== undefined && p2x !== undefined && p2y !== undefined) {
+      this.lens.p1 = { x: p1x, y: p1y };
+      this.lens.p2 = { x: p2x, y: p2y };
+    }
+    this.rebuild();
+  }
+
   /**
    * Attach a 2-axis drag to a corner handle:
    *   • Aperture-axis component → resizes height (p1↔p2 distance), keeping the
@@ -220,9 +254,16 @@ export class SphericalLensView extends GlassView {
    *             determines sign of the d change for horizontal drag).
    */
   private attachHeightDrag(handle: Circle, side: "p1" | "p2", optSide: "left" | "right"): void {
+    const historyHooks = createDragHistoryHooks(
+      "Resize lens",
+      () => this.captureLensState(),
+      (values) => this.restoreLensState(values),
+    );
     const drag = new RichDragListener({
       tandem: this.glassTandem.createTandem(`heightDragListener${side}${optSide}`),
       transform: this.modelViewTransform,
+      start: historyHooks.start,
+      end: historyHooks.end,
       drag: (_event, listener) => {
         const { x: dx, y: dy } = listener.modelDelta;
         const p1 = this.lens.p1;
@@ -281,9 +322,16 @@ export class SphericalLensView extends GlassView {
 
   /** Attach rotation drag to the rotation handle. */
   private attachRotationDrag(): void {
+    const historyHooks = createDragHistoryHooks(
+      "Rotate lens",
+      () => this.captureLensState(),
+      (values) => this.restoreLensState(values),
+    );
     const drag = new RichDragListener({
       tandem: this.glassTandem.createTandem("rotationDragListener"),
       transform: this.modelViewTransform,
+      start: historyHooks.start,
+      end: historyHooks.end,
       drag: (_event, listener) => {
         const { x: dx, y: dy } = listener.modelDelta;
         if (Math.abs(dx) < 1e-12 && Math.abs(dy) < 1e-12) {
@@ -338,9 +386,16 @@ export class SphericalLensView extends GlassView {
    * `surface` selects which control point to move: "r1" (left, path[5]) or "r2" (right, path[2]).
    */
   private attachCurvatureDrag(handle: Circle, surface: "r1" | "r2"): void {
+    const historyHooks = createDragHistoryHooks(
+      "Adjust lens curvature",
+      () => this.captureLensState(),
+      (values) => this.restoreLensState(values),
+    );
     const drag = new RichDragListener({
       tandem: this.glassTandem.createTandem(`curvatureDragListener${surface}`),
       transform: this.modelViewTransform,
+      start: historyHooks.start,
+      end: historyHooks.end,
       drag: (_event, listener) => {
         const { x: dx, y: dy } = listener.modelDelta;
 

--- a/src/common/view/glass/TypedPrismView.ts
+++ b/src/common/view/glass/TypedPrismView.ts
@@ -34,7 +34,7 @@ import {
 } from "../../../OpticsLabConstants.js";
 import OpticsLabNamespace from "../../../OpticsLabNamespace.js";
 import type { Glass } from "../../model/glass/Glass.js";
-import { createHandle } from "../ViewHelpers.js";
+import { createDragHistoryHooks, createHandle } from "../ViewHelpers.js";
 import type { ViewOptionsModel } from "../ViewOptionsModel.js";
 import { GlassView } from "./GlassView.js";
 
@@ -145,15 +145,67 @@ export class TypedPrismView extends GlassView {
   // Drag wiring
   // ═══════════════════════════════════════════════════════════════════════════
 
+  /** Flatten the prism geometry (path points + width/height/rotation) into a snapshot for undo. */
+  private capturePrismState(): number[] {
+    const values: number[] = [];
+    for (const p of this.glass.path) {
+      values.push(p.x, p.y);
+    }
+    if (hasWidthHeight(this.glass)) {
+      values.push(this.glass.width, this.glass.height, this.glass.rotation);
+    }
+    return values;
+  }
+
+  /** Restore a snapshot produced by capturePrismState() and refresh the view. */
+  private restorePrismState(values: number[]): void {
+    const path = this.glass.path;
+    for (let i = 0; i < path.length; i++) {
+      const p = path[i];
+      const x = values[2 * i];
+      const y = values[2 * i + 1];
+      if (p && x !== undefined && y !== undefined) {
+        p.x = x;
+        p.y = y;
+      }
+    }
+    if (hasWidthHeight(this.glass)) {
+      const o = path.length * 2;
+      const w = values[o];
+      const h = values[o + 1];
+      const r = values[o + 2];
+      // Assign the fields directly — the path coordinates above already hold
+      // the exact restored shape, so recomputing via setWidth/setHeight would
+      // discard them.
+      if (w !== undefined) {
+        this.glass.width = w;
+      }
+      if (h !== undefined) {
+        this.glass.height = h;
+      }
+      if (r !== undefined) {
+        this.glass.rotation = r;
+      }
+    }
+    this.rebuild();
+  }
+
   /**
    * Scale drag: dragging the handle at vertexIndex moves that vertex radially,
    * and ALL other vertices are scaled by the same ratio so the prism shape is
    * preserved.
    */
   private attachScaleDrag(handle: Circle, vertexIndex: number): void {
+    const historyHooks = createDragHistoryHooks(
+      "Resize prism",
+      () => this.capturePrismState(),
+      (values) => this.restorePrismState(values),
+    );
     const drag = new RichDragListener({
       tandem: this.glassTandem.createTandem(`scaleDragListener${vertexIndex}`),
       transform: this.modelViewTransform,
+      start: historyHooks.start,
+      end: historyHooks.end,
       drag: (_event, listener) => {
         const { x: dx, y: dy } = listener.modelDelta;
         const c = this.getCentroid();
@@ -206,9 +258,16 @@ export class TypedPrismView extends GlassView {
    * faces keep a minimum positive width (width − height ≥ DOVE_MIN_TOP_FACE).
    */
   private attachWidthHeightDrag(handle: Circle, vertexIndex: number, wh: WidthHeightGlass, isDove: boolean): void {
+    const historyHooks = createDragHistoryHooks(
+      "Resize prism",
+      () => this.capturePrismState(),
+      (values) => this.restorePrismState(values),
+    );
     const drag = new RichDragListener({
       tandem: this.glassTandem.createTandem(`widthHeightDragListener${vertexIndex}`),
       transform: this.modelViewTransform,
+      start: historyHooks.start,
+      end: historyHooks.end,
       drag: (_event, listener) => {
         const { x: dx, y: dy } = listener.modelDelta;
         const path = this.glass.path;
@@ -276,9 +335,16 @@ export class TypedPrismView extends GlassView {
    * about its centroid.
    */
   private attachRotationDrag(): void {
+    const historyHooks = createDragHistoryHooks(
+      "Rotate prism",
+      () => this.capturePrismState(),
+      (values) => this.restorePrismState(values),
+    );
     const drag = new RichDragListener({
       tandem: this.glassTandem.createTandem("rotationDragListener"),
       transform: this.modelViewTransform,
+      start: historyHooks.start,
+      end: historyHooks.end,
       drag: (_event, listener) => {
         const { x: dx, y: dy } = listener.modelDelta;
         if (Math.abs(dx) < ROTATION_DRAG_DELTA_MIN && Math.abs(dy) < ROTATION_DRAG_DELTA_MIN) {

--- a/tests/drag-interactions.test.ts
+++ b/tests/drag-interactions.test.ts
@@ -1,0 +1,183 @@
+/**
+ * drag-interactions.test.ts
+ *
+ * Regression tests for drag/resize interaction bugs found in code review:
+ *
+ *   1. createDragHistoryHooks — the shared start/end hooks that make custom
+ *      geometry drags (lens curvature, prism scale/rotation) undoable.
+ *   2. GlassView previously disposed and recreated its bodyDragListener when
+ *      a prism vertex was added or removed. External observers
+ *      (RayTracingCommonView) link to bodyDragListener.isPressedProperty once
+ *      at view creation, so the recreation silently broke drag-layer
+ *      reparenting and drop-on-carousel deletion. The listener must now be
+ *      stable across vertex changes.
+ *   3. Prism vertex add/remove are recorded as undoable commands.
+ */
+
+import { Vector2 } from "scenerystack/dot";
+import { ModelViewTransform2 } from "scenerystack/phetcommon";
+import { describe, expect, it } from "vitest";
+import { Glass } from "../src/common/model/glass/Glass.js";
+import { CommandHistory } from "../src/common/model/optics/CommandHistory.js";
+import { GlassView } from "../src/common/view/glass/GlassView.js";
+import { sceneHistoryRegistry } from "../src/common/view/SceneHistoryRegistry.js";
+import { createDragHistoryHooks } from "../src/common/view/ViewHelpers.js";
+
+const mvt = ModelViewTransform2.createSinglePointScaleInvertedYMapping(Vector2.ZERO, new Vector2(500, 400), 100);
+
+/** Run a test body with a fresh CommandHistory installed in the registry. */
+function withHistory<T>(body: (history: CommandHistory) => T): T {
+  const history = new CommandHistory();
+  sceneHistoryRegistry.setHistory(history);
+  try {
+    return body(history);
+  } finally {
+    sceneHistoryRegistry.setHistory(null);
+  }
+}
+
+/** Fire the pointer-down handler of the first input listener on a node. */
+function fireDown(node: { inputListeners: unknown[] }): void {
+  const listener = node.inputListeners[0] as { down?: (event: { handle: () => void }) => void };
+  listener.down?.({
+    handle: () => {
+      /* no-op */
+    },
+  });
+}
+
+// ── 1. createDragHistoryHooks ───────────────────────────────────────────────
+
+describe("createDragHistoryHooks", () => {
+  it("records an undoable snapshot command for a changed drag", () => {
+    withHistory((history) => {
+      const state = { x: 1, y: 2 };
+      const hooks = createDragHistoryHooks(
+        "Test drag",
+        () => [state.x, state.y],
+        (v) => {
+          state.x = v[0] ?? state.x;
+          state.y = v[1] ?? state.y;
+        },
+      );
+
+      hooks.start();
+      state.x = 10;
+      state.y = 20;
+      hooks.end();
+
+      expect(history.canUndo).toBe(true);
+      history.undo();
+      expect(state).toEqual({ x: 1, y: 2 });
+      history.redo();
+      expect(state).toEqual({ x: 10, y: 20 });
+    });
+  });
+
+  it("records nothing when the drag did not change the state", () => {
+    withHistory((history) => {
+      const state = { x: 1 };
+      const hooks = createDragHistoryHooks(
+        "Test drag",
+        () => [state.x],
+        (v) => {
+          state.x = v[0] ?? state.x;
+        },
+      );
+      hooks.start();
+      hooks.end();
+      expect(history.canUndo).toBe(false);
+    });
+  });
+});
+
+// ── 2 & 3. GlassView vertex add/remove ──────────────────────────────────────
+
+/** Access GlassView internals that the tests must reach. */
+interface GlassViewInternals {
+  addButtons: Array<{ inputListeners: unknown[] }>;
+  handles: Array<{ children: Array<{ inputListeners: unknown[] }> }>;
+  bodyDragPoints: unknown[];
+}
+
+function makeTriangleGlassView(): { glass: Glass; view: GlassView; internals: GlassViewInternals } {
+  const glass = new Glass(
+    [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0.5, y: 1 },
+    ],
+    1.5,
+  );
+  const view = new GlassView(glass, mvt);
+  return { glass, view, internals: view as unknown as GlassViewInternals };
+}
+
+describe("GlassView vertex add/remove", () => {
+  it("keeps the same bodyDragListener instance across a vertex add", () => {
+    withHistory(() => {
+      const { glass, view, internals } = makeTriangleGlassView();
+      const listenerBefore = view.bodyDragListener;
+      expect(internals.bodyDragPoints).toHaveLength(3);
+
+      fireDown(internals.addButtons[0] as { inputListeners: unknown[] });
+
+      expect(glass.path).toHaveLength(4);
+      // The listener must be the exact same instance — recreating it severs
+      // the isPressedProperty link held by RayTracingCommonView.
+      expect(view.bodyDragListener).toBe(listenerBefore);
+      // The stable points array must now cover the new vertex.
+      expect(internals.bodyDragPoints).toHaveLength(4);
+
+      view.dispose();
+      glass.dispose();
+    });
+  });
+
+  it("records vertex add as an undoable command", () => {
+    withHistory((history) => {
+      const { glass, view, internals } = makeTriangleGlassView();
+
+      fireDown(internals.addButtons[1] as { inputListeners: unknown[] });
+      expect(glass.path).toHaveLength(4);
+      expect(history.canUndo).toBe(true);
+
+      history.undo();
+      expect(glass.path).toHaveLength(3);
+      history.redo();
+      expect(glass.path).toHaveLength(4);
+
+      view.dispose();
+      glass.dispose();
+    });
+  });
+
+  it("records vertex remove as an undoable command that restores the vertex", () => {
+    withHistory((history) => {
+      const { glass, view, internals } = makeTriangleGlassView();
+
+      // Grow to 4 vertices first (remove buttons only exist above 3).
+      fireDown(internals.addButtons[0] as { inputListeners: unknown[] });
+      expect(glass.path).toHaveLength(4);
+      const removedVertex = glass.path[1];
+
+      // Each handle carries its remove button as a child.
+      const handleForVertex1 = internals.handles[1] as { children: Array<{ inputListeners: unknown[] }> };
+      const removeButton = handleForVertex1.children.find((c) => c.inputListeners.length > 0);
+      expect(removeButton).toBeDefined();
+      if (!removeButton) {
+        return;
+      }
+      fireDown(removeButton);
+      expect(glass.path).toHaveLength(3);
+      expect(glass.path).not.toContain(removedVertex);
+
+      history.undo();
+      expect(glass.path).toHaveLength(4);
+      expect(glass.path[1]).toBe(removedVertex);
+
+      view.dispose();
+      glass.dispose();
+    });
+  });
+});

--- a/tests/review-regressions.test.ts
+++ b/tests/review-regressions.test.ts
@@ -1,0 +1,278 @@
+/**
+ * review-regressions.test.ts
+ *
+ * Regression tests for bugs found in a full code review of the simulation:
+ *
+ *   1. IdealLens deflected back-side rays with the wrong sign — a converging
+ *      lens acted as a diverging lens for rays traveling against its normal.
+ *   2. Five element types (AperturedParabolicMirror, BiconvexLens,
+ *      BiconcaveLens, PlanoConvexLens, PlanoConcaveLens) serialized with type
+ *      keys that deserializeElement did not recognize, silently dropping them
+ *      from saved scenes and breaking duplicate + PhET-iO state restore.
+ *      Additionally, plano lenses serialize a flat surface as r = Infinity,
+ *      which JSON.stringify turns into null — previously a hard parse error.
+ *   3. Arc-based elements (ArcMirror, curved DetectorElement, Glass arc edges)
+ *      reported bounding boxes of just their control points, but an arc bulges
+ *      beyond them (dramatically for arcs > 180°). The spatial index culls by
+ *      bounds, so rays could pass straight through the element.
+ *   4. Beam-type sources emitted rays without sourceId/rayIndex, so image
+ *      detection pooled rays from different sources into one shared group,
+ *      producing spurious cross-source image markers.
+ */
+
+import { Tandem } from "scenerystack/tandem";
+import { describe, expect, it } from "vitest";
+import { LineBlocker } from "../src/common/model/blockers/LineBlocker.js";
+import { BiconcaveLens } from "../src/common/model/glass/BiconcaveLens.js";
+import { BiconvexLens } from "../src/common/model/glass/BiconvexLens.js";
+import { IdealLens } from "../src/common/model/glass/IdealLens.js";
+import { PlanoConcaveLens } from "../src/common/model/glass/PlanoConcaveLens.js";
+import { PlanoConvexLens } from "../src/common/model/glass/PlanoConvexLens.js";
+import { SphericalLens } from "../src/common/model/glass/SphericalLens.js";
+import { BeamSource } from "../src/common/model/light-sources/BeamSource.js";
+import { DivergentBeam } from "../src/common/model/light-sources/DivergentBeam.js";
+import { SingleRaySource } from "../src/common/model/light-sources/SingleRaySource.js";
+import { AperturedParabolicMirror } from "../src/common/model/mirrors/AperturedParabolicMirror.js";
+import { ArcMirror } from "../src/common/model/mirrors/ArcMirror.js";
+import { deserializeElement } from "../src/common/model/optics/elementSerialization.js";
+import { arcBounds, point } from "../src/common/model/optics/Geometry.js";
+import { OpticsScene } from "../src/common/model/optics/OpticsScene.js";
+import type { SimulationRay } from "../src/common/model/optics/OpticsTypes.js";
+import { RayTracer } from "../src/common/model/optics/RayTracer.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRay(origin: { x: number; y: number }, direction: { x: number; y: number }): SimulationRay {
+  return {
+    origin: point(origin.x, origin.y),
+    direction: point(direction.x, direction.y),
+    brightnessS: 0.5,
+    brightnessP: 0.5,
+    gap: false,
+    isNew: false,
+  };
+}
+
+/** JSON round-trip exactly as OpticsScene.toJSON / fromJSON does per element. */
+function roundTrip(el: { serialize(): Record<string, unknown>; id: string }): ReturnType<typeof deserializeElement> {
+  const state = JSON.parse(JSON.stringify({ ...el.serialize(), id: el.id })) as Record<string, unknown>;
+  return deserializeElement(state);
+}
+
+// ── 1. IdealLens back-side deflection ───────────────────────────────────────
+
+describe("IdealLens deflection sign", () => {
+  // Lens on the y-axis from (0,-1) to (0,1); segmentNormal is (+1, 0), f = 1.
+  const lens = (): IdealLens => new IdealLens(point(0, -1), point(0, 1), 1);
+
+  it("converges a front-side parallel ray to the focal point", () => {
+    const l = lens();
+    const ray = makeRay({ x: -2, y: 0.5 }, { x: 1, y: 0 });
+    const hit = l.checkRayIntersection(ray);
+    expect(hit).not.toBeNull();
+    if (!hit) {
+      return;
+    }
+    const result = l.onRayIncident(ray, hit);
+    expect(result.isAbsorbed).toBe(false);
+    const dir = result.outgoingRay?.direction;
+    expect(dir).toBeDefined();
+    if (!dir) {
+      return;
+    }
+    // Outgoing ray from (0, 0.5) must pass through the focus (1, 0):
+    // direction ∝ (1, -0.5).
+    expect(dir.x).toBeGreaterThan(0);
+    expect(dir.y / dir.x).toBeCloseTo(-0.5, 10);
+  });
+
+  it("converges a back-side parallel ray to the focal point on the exit side", () => {
+    const l = lens();
+    const ray = makeRay({ x: 2, y: 0.5 }, { x: -1, y: 0 });
+    const hit = l.checkRayIntersection(ray);
+    expect(hit).not.toBeNull();
+    if (!hit) {
+      return;
+    }
+    const result = l.onRayIncident(ray, hit);
+    expect(result.isAbsorbed).toBe(false);
+    const dir = result.outgoingRay?.direction;
+    expect(dir).toBeDefined();
+    if (!dir) {
+      return;
+    }
+    // Outgoing ray from (0, 0.5) must pass through the focus (-1, 0):
+    // direction ∝ (-1, -0.5). Before the fix the deflection sign was
+    // inverted, sending the ray away from the axis (diverging behaviour).
+    expect(dir.x).toBeLessThan(0);
+    expect(dir.y / dir.x).toBeCloseTo(0.5, 10);
+  });
+});
+
+// ── 2. Missing element deserialization ──────────────────────────────────────
+
+describe("serialization round-trip of previously missing element types", () => {
+  it("restores an AperturedParabolicMirror", () => {
+    const src = new AperturedParabolicMirror(point(-2, 0), point(2, 0), point(0, 1), 0.5);
+    const restored = roundTrip(src);
+    expect(restored).toBeInstanceOf(AperturedParabolicMirror);
+    const m = restored as AperturedParabolicMirror;
+    expect(m.id).toBe(src.id);
+    expect(m.p3).toEqual(src.p3);
+    expect(m.apertureHalfWidth).toBe(0.5);
+  });
+
+  it("restores a BiconvexLens with its geometry", () => {
+    const src = new BiconvexLens(point(0, -1), point(0, 1), 3, 1.6);
+    const restored = roundTrip(src);
+    expect(restored).toBeInstanceOf(BiconvexLens);
+    const l = restored as BiconvexLens;
+    expect(l.refIndex).toBe(1.6);
+    const { d, r1, r2 } = l.getDR1R2();
+    const orig = src.getDR1R2();
+    expect(d).toBeCloseTo(orig.d, 6);
+    expect(r1).toBeCloseTo(orig.r1, 6);
+    expect(r2).toBeCloseTo(orig.r2, 6);
+  });
+
+  it("restores a BiconcaveLens", () => {
+    const src = new BiconcaveLens(point(0, -1), point(0, 1), 3, 1.5);
+    const restored = roundTrip(src);
+    expect(restored).toBeInstanceOf(BiconcaveLens);
+    const { r1, r2 } = (restored as BiconcaveLens).getDR1R2();
+    expect(r1).toBeLessThan(0);
+    expect(r2).toBeGreaterThan(0);
+  });
+
+  it("restores a PlanoConvexLens whose flat surface serialized as null", () => {
+    const src = new PlanoConvexLens(point(0, -1), point(0, 1), 3, 1.5);
+    // Flat surface: r1 is Infinity in the model, null after JSON.stringify.
+    const json = JSON.parse(JSON.stringify({ ...src.serialize(), id: src.id })) as Record<string, unknown>;
+    expect(json["r1"]).toBeNull();
+    const restored = deserializeElement(json);
+    expect(restored).toBeInstanceOf(PlanoConvexLens);
+    const { r1, r2 } = (restored as PlanoConvexLens).getDR1R2();
+    expect(Number.isFinite(r1)).toBe(false);
+    expect(r2).toBeLessThan(0);
+  });
+
+  it("restores a PlanoConcaveLens", () => {
+    const src = new PlanoConcaveLens(point(0, -1), point(0, 1), 3, 1.5);
+    const restored = roundTrip(src);
+    expect(restored).toBeInstanceOf(PlanoConcaveLens);
+    const { r1, r2 } = (restored as PlanoConcaveLens).getDR1R2();
+    expect(Number.isFinite(r1)).toBe(false);
+    expect(r2).toBeGreaterThan(0);
+  });
+
+  it("restores a generic SphericalLens with one flat surface (r → null in JSON)", () => {
+    const src = new SphericalLens(point(0, -1), point(0, 1), Infinity, -3, 1.5);
+    const restored = roundTrip(src);
+    expect(restored).toBeInstanceOf(SphericalLens);
+  });
+
+  it("duplicateElement works for the previously missing types", () => {
+    const scene = new OpticsScene(Tandem.OPT_OUT);
+    const lens = new BiconvexLens(point(0, -1), point(0, 1), 3, 1.5);
+    const mirror = new AperturedParabolicMirror(point(-2, 0), point(2, 0), point(0, 1), 0.5);
+    scene.addElement(lens, false);
+    scene.addElement(mirror, false);
+
+    expect(scene.duplicateElement(lens.id, point(1, 0))).toBeInstanceOf(BiconvexLens);
+    expect(scene.duplicateElement(mirror.id, point(1, 0))).toBeInstanceOf(AperturedParabolicMirror);
+  });
+});
+
+// ── 3. Arc bounding boxes ───────────────────────────────────────────────────
+
+describe("arc-aware bounding boxes", () => {
+  it("arcBounds includes circle extremes on a major arc", () => {
+    // Major arc of the unit circle: endpoints near the top, passing through
+    // the bottom (0,-1) — spans ~340°.
+    const a = (Math.PI * 80) / 180;
+    const p1 = point(Math.cos(a), Math.sin(a));
+    const p2 = point(-Math.cos(a), Math.sin(a));
+    const p3 = point(0, -1);
+    const b = arcBounds(p1, p2, p3);
+    expect(b.minX).toBeCloseTo(-1, 6);
+    expect(b.maxX).toBeCloseTo(1, 6);
+    expect(b.minY).toBeCloseTo(-1, 6);
+    expect(b.maxY).toBeCloseTo(Math.sin(a), 6);
+  });
+
+  it("arcBounds of a minor arc does not include the far side of the circle", () => {
+    // Minor arc across the top of the unit circle.
+    const a = (Math.PI * 30) / 180;
+    const p1 = point(-Math.cos(a), Math.sin(a));
+    const p2 = point(Math.cos(a), Math.sin(a));
+    const p3 = point(0, 1);
+    const b = arcBounds(p1, p2, p3);
+    expect(b.maxY).toBeCloseTo(1, 6);
+    expect(b.minY).toBeCloseTo(Math.sin(a), 6);
+  });
+
+  it("rays hit the bulge of a wide ArcMirror in a spatially indexed scene", () => {
+    // Major-arc mirror around the origin (radius-10 circle, gap at the top).
+    // The bulge at (-10, 0) sits many spatial-index cells away from the
+    // bounding box of the three control points, so an underestimated box
+    // makes the tracer miss the mirror entirely.
+    const r = 10;
+    const a = (Math.PI * 80) / 180;
+    const mirror = new ArcMirror(
+      point(r * Math.cos(a), r * Math.sin(a)),
+      point(-r * Math.cos(a), r * Math.sin(a)),
+      point(0, -r),
+    );
+
+    // A ray traveling straight down the x = -9 column. Its cell path never
+    // overlaps the narrow control-point box (|x| ≤ r·cos80° ≈ 1.7), so with
+    // underestimated bounds the mirror is never even tested for intersection.
+    const source = new SingleRaySource(point(-9, 13), point(-9, 12), 1, 550);
+
+    // Distant finite elements so the spatial index uses grid traversal
+    // instead of the ≤4-element return-everything fast path.
+    const blockers = [0, 1, 2, 3].map((i) => new LineBlocker(point(50, 10 * i), point(51, 10 * i)));
+
+    const tracer = new RayTracer([source, mirror, ...blockers]);
+    const result = tracer.trace();
+
+    // The ray must terminate on the mirror at (-9, +sqrt(r² - 81)) rather
+    // than escaping through it.
+    const hitY = Math.sqrt(r * r - 81);
+    const hitSegment = result.segments.find(
+      (s) => !s.isExtension && Math.abs(s.p2.x + 9) < 1e-6 && Math.abs(s.p2.y - hitY) < 1e-6,
+    );
+    expect(hitSegment).toBeDefined();
+  });
+});
+
+// ── 4. Beam sources tag rays with sourceId/rayIndex ─────────────────────────
+
+describe("beam-type sources tag emitted rays for per-source grouping", () => {
+  it("BeamSource rays carry sourceId and sequential rayIndex", () => {
+    const src = new BeamSource(point(0, -1), point(0, 1), 0.5, 550);
+    const rays = src.emitRays(10, "images");
+    expect(rays.length).toBeGreaterThan(1);
+    for (const [i, ray] of rays.entries()) {
+      expect(ray.sourceId).toBe(src.id);
+      expect(ray.rayIndex).toBe(i);
+    }
+  });
+
+  it("DivergentBeam rays carry sourceId and sequential rayIndex", () => {
+    const src = new DivergentBeam(point(0, -1), point(0, 1), 0.5, 550, 20);
+    const rays = src.emitRays(10, "images");
+    expect(rays.length).toBeGreaterThan(1);
+    for (const [i, ray] of rays.entries()) {
+      expect(ray.sourceId).toBe(src.id);
+      expect(ray.rayIndex).toBe(i);
+    }
+  });
+
+  it("SingleRaySource ray carries sourceId", () => {
+    const src = new SingleRaySource(point(0, 0), point(1, 0), 1, 550);
+    const rays = src.emitRays(10, "images");
+    expect(rays).toHaveLength(1);
+    expect(rays[0]?.sourceId).toBe(src.id);
+  });
+});


### PR DESCRIPTION
- IdealLens: the thin-lens deflection slopeOut = slopeIn - h/f only holds
  for rays traveling along the lens normal; rays incident from the back
  side got the kick with the wrong sign, making a converging lens act as
  a diverging one. The deflection now flips with sign(rayDirPer).

- elementSerialization: AperturedParabolicMirror, BiconvexLens,
  BiconcaveLens, PlanoConvexLens, and PlanoConcaveLens serialized with
  type keys that deserializeElement did not handle, so saved scenes and
  duplicateElement silently dropped them and PhET-iO state restore threw.
  All five are now deserializable, and radius-of-curvature fields accept
  null (JSON.stringify output for the Infinity used by flat surfaces).

- Arc bounding boxes: ArcMirror, curved DetectorElement, and Glass arc
  edges reported the AABB of their control points only, but an arc bulges
  beyond them (dramatically past 180 degrees). Since the spatial index
  culls candidates by bounds, rays could pass straight through the
  element in scenes with five or more finite elements. New
  Geometry.arcBounds includes the circle's axis-extreme points that lie
  on the arc.

- Beam-type sources (BeamSource, DivergentBeam, SingleRaySource,
  ContinuousSpectrumSource) emitted rays without sourceId/rayIndex, so
  image detection pooled rays from different sources into one shared
  group and could report spurious cross-source image markers.

Adds tests/review-regressions.test.ts covering all four fixes; the
IdealLens and ArcMirror tests were verified to fail against the
unfixed code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PXJzZgeaTkYuFjpQAVg8ix