### PR TITLE
Stop preset loads from retaining superseded elements in undo history

### DIFF
--- a/src/presets/PresetsModel.ts
+++ b/src/presets/PresetsModel.ts
@@ -22,11 +22,19 @@ export class PresetsModel extends RayTracingCommonModel {
     // Load elements whenever the selected preset changes.
     this.selectedPresetProperty.link((presetId) => {
       this.scene.clearElements();
+      // Loading a preset is a programmatic scene replacement, not a user edit,
+      // so it must not record undo history: (1) undoing a preset load
+      // element-by-element is nonsensical UX, and (2) the "Add" command closures
+      // would otherwise keep every superseded preset element reachable (up to the
+      // MAX_HISTORY_SIZE cap) long after clearElements() removed it from the scene.
+      // Clear any prior history too, since undo across a preset boundary is
+      // meaningless and would reference elements clearElements() just disposed.
+      this.scene.history.clear();
       const descriptors = getPresetDescriptors();
       const preset = descriptors.find((d) => d.id === presetId);
       if (preset) {
         for (const element of preset.createElements()) {
-          this.scene.addElement(element);
+          this.scene.addElement(element, false);
         }
       }
     });

--- a/tests/fuzz/fuzz.spec.ts
+++ b/tests/fuzz/fuzz.spec.ts
@@ -10,9 +10,9 @@
 import { expect, test } from "@playwright/test";
 
 const FUZZ_DURATION = parseInt(process.env["FUZZ_DURATION"] || "15", 10) * 1000;
-const FUZZ_SEED = process.env["FUZZ_SEED"] || Math.floor(Math.random() * 1_000_000).toString();
-const FUZZ_RATE = process.env["FUZZ_RATE"] || "100";
-const FUZZ_POINTERS = process.env["FUZZ_POINTERS"] || "1";
+const FUZZ_SEED: string = process.env["FUZZ_SEED"] || Math.floor(Math.random() * 1_000_000).toString();
+const FUZZ_RATE: string = process.env["FUZZ_RATE"] || "100";
+const FUZZ_POINTERS: string = process.env["FUZZ_POINTERS"] || "1";
 
 interface ConsoleMessage {
   type: string;

--- a/tests/memory-leak.test.ts
+++ b/tests/memory-leak.test.ts
@@ -670,4 +670,50 @@ describe("Memory leak regression", () => {
       );
     }
   });
+
+  // ── Preset switching does not retain superseded elements ──────────────────
+  //
+  // PresetsModel reloads a single long-lived scene on every preset change:
+  //   scene.clearElements(); scene.history.clear(); scene.addElement(el, false);
+  //
+  // clearElements() removes elements from the group, but any undo command that
+  // captured them would keep them reachable.  This test mirrors the preset-load
+  // flow: elements from an earlier "preset" must be collectible once a later
+  // preset has replaced them, even though the scene itself lives on.
+  //
+  // Regression guard: loading a preset with recordHistory=true (or without
+  // clearing history) would leave the previous preset's elements pinned in the
+  // undo stack, so the round-1 WeakRefs below would still deref().
+  it("preset switching releases the previous preset's elements", async () => {
+    const round1Refs: Array<{ key: string; ref: WeakRef<object> }> = [];
+    // The scene is intentionally kept alive for the whole test — it models the
+    // single scene owned by PresetsModel across many preset switches.
+    const scene = new OpticsScene(Tandem.OPT_OUT);
+    const presetKeys = ALL_KEYS.slice(0, 8);
+
+    // Load "preset 1", tracking its elements.
+    const loadPreset = (refs: Array<{ key: string; ref: WeakRef<object> }> | null): void => {
+      scene.clearElements();
+      scene.history.clear();
+      for (const key of presetKeys) {
+        const el = createDefaultElement(key, 0, 0);
+        if (refs) {
+          refs.push({ key, ref: new WeakRef<object>(el) });
+        }
+        scene.addElement(el, false);
+      }
+    };
+
+    loadPreset(round1Refs);
+    // Switch to "preset 2" — round-1 elements are now superseded.
+    loadPreset(null);
+
+    await forceGC();
+
+    const leaked = round1Refs.filter((e) => e.ref.deref() !== undefined);
+    scene.dispose();
+    if (leaked.length > 0) {
+      expect.fail(`Preset-1 elements retained after switching presets: ${leaked.map((e) => e.key).join(", ")}`);
+    }
+  });
 });


### PR DESCRIPTION
PresetsModel reloads a single long-lived scene on every preset switch via
clearElements() + addElement(). It used the default recordHistory=true, so
each preset element pushed an "Add" command whose closure captured the
element. clearElements() removed the previous preset's elements from the
scene but left those commands in the undo stack, keeping the superseded
elements reachable (up to the MAX_HISTORY_SIZE cap of 100) and polluting the
user's undo history with per-element preset-load steps.

Load preset elements with recordHistory=false (matching OpticsScene.fromJSON
and other programmatic loads) and clear history on each preset switch, since
undo across a preset boundary is meaningless and would reference elements
clearElements() just disposed.

Add a memory-leak regression test that mirrors the preset-switch flow and
asserts the previous preset's elements are collected once replaced, even
though the scene itself lives on.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HU1sgvettEX2Nkrpsuenh7