### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md
+
+OpticsLab is a client-only geometric optics simulation built on SceneryStack (PhET-style). There is no backend, database, or external service — everything runs in the browser. See `README.md` for scripts and `CLAUDE.md` for architecture/model details.
+
+## Cursor Cloud specific instructions
+
+- Dependencies are installed by the startup update script (`npm ci`). Do not re-run installs unless dependencies changed.
+- Node ≥ 22 is required (`engines`). The repo uses npm (`package-lock.json`); do not switch package managers.
+- Run the dev server with `npm start` (Vite on `http://localhost:5173`). This is the correct way to develop/test the app in dev mode; do not use the production `npm run build` output for interactive testing. Testing the UI requires a browser navigating to that URL.
+- Standard commands are documented in `README.md`: `npm run lint` (Biome), `npm run check` (tsc type-check), `npm test` (Vitest), `npm run build` (tsc + Vite prod build).
+- Non-obvious: `npm test` (Vitest) is slow (~90s for the full suite, 400+ tests) because of the physics/ray-tracing model tests — this is expected, not a hang.
+- Non-obvious: git hooks are enabled via the `prepare` script (`core.hooksPath .githooks`). The pre-push hook runs `npm run lint` + `npm run check`, so pushes fail if either fails. The pre-commit hook auto-formats staged files with Biome.
+- Icon generation (`npm run icons`) is optional and NOT needed to run the dev server or tests; skip it unless working on PWA icons.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for OpticsLab (client-only SceneryStack geometric optics simulation) for Cursor Cloud agents, and verifies it works end-to-end.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing durable, non-obvious startup/run caveats (dev server usage, slow Vitest suite, git hooks, optional icon generation).
- Update script configured as `npm ci` (minimal dependency refresh on VM startup).

## Verification

All standard commands were run successfully in the cloud VM:

| Step | Command | Result |
|---|---|---|
| Install | `npm ci` | 494 packages, OK |
| Lint | `npm run lint` | Checked 168 files, no issues |
| Type check | `npm run check` | Passed (3 tsconfig targets) |
| Tests | `npm test` | 413 passed (4 files) |
| Build | `npm run build` | Built `dist/` OK |
| Dev server | `npm start` | Vite on `http://localhost:5173`, HTTP 200 |

### Hello-world task

Built a scene on the Lab screen: added a light beam, then a spherical lens in its path. The ray-tracing engine responded in real time — parallel rays converge through the lens to a focal point.

[opticslab_lab_ray_tracing_demo.mp4](https://cursor.com/agents/bc-8cd5c18e-9428-49b1-9f99-48727adfdf1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopticslab_lab_ray_tracing_demo.mp4)

[Rays converging through a spherical lens](https://cursor.com/agents/bc-8cd5c18e-9428-49b1-9f99-48727adfdf1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopticslab_lens_ray_tracing.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cd5c18e-9428-49b1-9f99-48727adfdf1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cd5c18e-9428-49b1-9f99-48727adfdf1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

