### PR TITLE
chore: align Node engines and @types/node with fleet Node 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.5",
         "@playwright/test": "^1.62.0",
-        "@types/node": "^26.1.1",
+        "@types/node": "^24.13.3",
         "canvas": "^3.2.3",
         "happy-dom": "^20.11.1",
         "jsdom": "^30.0.0",
@@ -28,7 +28,7 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24"
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
@@ -3968,13 +3968,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -8734,9 +8734,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.5",
     "@playwright/test": "^1.62.0",
-    "@types/node": "^26.1.1",
+    "@types/node": "^24.13.3",
     "canvas": "^3.2.3",
     "happy-dom": "^20.11.1",
     "jsdom": "^30.0.0",
@@ -61,7 +61,7 @@
     "vitest": "^4.1.10"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24"
   },
   "overrides": {
     "serialize-javascript": "^7.0.5",


### PR DESCRIPTION
## Summary
- Raise `engines.node` to `>=24` to match the org CI Node-24 rule.
- Pin `@types/node` to `^24.13.3` so the types major tracks the runtime (Dependabot ignores `@types/node` majors).
- Remove any stale `.nvmrc` / `.node-version` that disagreed with the fleet major.

## Test plan
- [ ] CI green on Node 24
- [ ] `npm install` / lint+check locally on Node 24