### PR TITLE
docs: rename TemplateSingleSim to SceneryStackTemplate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       prefix: "chore"
       include: "scope"
     # @types/node major versions track the Node.js runtime (see shared CI default).
-    # Bump TemplateSingleSim and repos together when CI node-version changes.
+    # Bump SceneryStackTemplate and repos together when CI node-version changes.
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]

--- a/src/common/view/OpticsLabScreenSummaryContent.ts
+++ b/src/common/view/OpticsLabScreenSummaryContent.ts
@@ -6,7 +6,7 @@
  * bench play area and the controls, and gives an interaction hint.
  *
  * Follows the OpenPhysics accessibility convention; see the canonical
- * TemplateSingleSim/SimScreenSummaryContent.ts. The current-details paragraph is
+ * SceneryStackTemplate/SimScreenSummaryContent.ts. The current-details paragraph is
  * static here because the scene's optical elements are held in a PhetioGroup
  * rather than a count Property; it can be made live by deriving a count.
  */


### PR DESCRIPTION
## Summary
- Replace leftover `TemplateSingleSim` references with `SceneryStackTemplate`
- Update "single-sim template" prose where present
- Fix stale `CREDITS.md` titles that still named the template

## Test plan
- [ ] No remaining `TemplateSingleSim` in this repo
- [ ] Comment/doc-only; no runtime behavior change