### PR TITLE
Use sibling Baseline for upstream references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ Thumbs.db
 .claude/settings.local.json
 
 # Optics simulation template
-optics-template/
 
 # CI / local npm audit artifact (must not be linted)
 audit.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Geometric optics simulation: ray tracing through lenses, mirrors, beam splitters
 - **Presets** — curated demonstration scenes
 - **Diffraction** — gratings-focused carousel
 
-**Ignore `optics-template/`** — reference material, not part of the shipped sim.
+**Upstream reference:** `../Baseline/OpticsLab/ray-optics` (OpenPhysics/Baseline); not part of the shipped sim.
 
 Physics for educators: `doc/model.md`. Architecture: `doc/implementation-notes.md`.
 


### PR DESCRIPTION
## Summary
- Point decompile scripts / docs at the sibling [`OpenPhysics/Baseline`](https://github.com/OpenPhysics/Baseline) repo for upstream Flash and other ground-truth sources.
- Stop relying on nested local reference clones (now centralized and deduplicated under Baseline).

## Test plan
- [ ] `../Baseline` is present (fleet bootstrap) and `../Baseline/scripts/fetch-baselines.sh` has been run for needed git pins
- [ ] `npm run decompile -- --list` resolves SWFs under `../Baseline/Astronomy/flash-animations` (NAAP sims)
- [ ] Sim still builds: `npm run lint && npm run check && npm run build`

Made with [Cursor](https://cursor.com)