### PR TITLE
chore: retrofit template hardening (security, PWA, overrides)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+      # Forced in package.json overrides (see CLAUDE.md → package.json overrides).
+      # Dependabot PRs would fight the pin / reopen known-accepted risk.
+      - dependency-name: "lodash"
+      - dependency-name: "three"
+      - dependency-name: "brace-expansion"
     groups:
       development-dependencies:
         dependency-type: "development"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,20 @@ it can be made live by deriving an element-count Property.
 
 - **Hardcoded colors:** wavelength-derived `rgba(...)` / canvas strokes in ray/SVG exporters and light-source views — physically tinted optics rendering, not UI theme tokens.
 
+
+### `package.json` overrides
+
+JSON cannot carry comments, so the rationale for forced transitive pins lives here. Prefer
+**tilde (`~`) or exact** versions — caret (`^`) lets minors drift under what is meant to be a
+hard pin. Dependabot ignores these three names (see `.github/dependabot.yml`) so it does not
+open PRs that fight the overrides. Revisit when SceneryStack drops or re-pins them upstream.
+
+| Override | Pin | Why |
+|---|---|---|
+| `lodash` | `~4.18.1` | SceneryStack declares `~4.17.12`. Bump clears Dependabot/npm advisories patched in 4.18.x (e.g. GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh). |
+| `three` | `~0.125.2` | SceneryStack declares `^0.104.0`. Floor is 0.125.0 for GHSA-fq6p-x6j3-cmmq (ReDoS). Staying on the 0.125 line avoids a larger API jump; **0.125.x still has open CVEs** (e.g. XSS GHSA-7vvq-7r29-5vg3, fixed only in ≥0.137.0). Remove this override if/when SceneryStack stops depending on `three` or pins a patched line itself. LightPropagation keeps a higher `three` pin — do not force 0.125 there. |
+| `brace-expansion` | `~5.0.9` | Transitive via `vite-plugin-pwa` / Workbox. Clears npm audit (originally GHSA-mh99-v99m-4gvg; keep ≥5.0.9 for GHSA-rgw5-rvv9-x895). |
+
 ## Testing
 
 Fleet-standard Vitest layout:
@@ -80,6 +94,8 @@ npm run lint && npm run check && npm run build
 npm test
 npm run generate-svg-icon   # regenerate icon SVG before icons
 ```
+
+`npm run release` intentionally skips `npm test` in some sims — append `&& npm test` before the version bump so a release cannot ship a failing suite.
 
 ## Development notes
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpticsLab
 
+[![CI](https://github.com/OpenPhysics/OpticsLab/actions/workflows/ci.yml/badge.svg)](https://github.com/OpenPhysics/OpticsLab/actions/workflows/ci.yml)
+
 A web-based geometric optics simulation built with [SceneryStack](https://scenerystack.org/). Build scenes
 with light sources, mirrors, lenses, beam splitters, and refracting interfaces.
 

--- a/index.html
+++ b/index.html
@@ -12,6 +12,28 @@
     <meta name="theme-color" content="#1a1a2e" />
     <meta name="phet-sim-level" content="production" />
 
+    <meta
+      name="description"
+      content="Web-based geometric optics simulation. Supports ray sources, parallel and divergent beams, mirrors, lenses, beam splitters, and refraction interfaces."
+    />
+
+    <!-- Open Graph (LMS / social share previews). Update og:url after deploy. -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="OpticsLab" />
+    <meta
+      property="og:description"
+      content="Web-based geometric optics simulation. Supports ray sources, parallel and divergent beams, mirrors, lenses, beam splitters, and refraction interfaces."
+    />
+    <meta property="og:image" content="./icons/icon-512.png" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="OpticsLab" />
+    <meta
+      name="twitter:description"
+      content="Web-based geometric optics simulation. Supports ray sources, parallel and divergent beams, mirrors, lenses, beam splitters, and refraction interfaces."
+    />
+    <meta name="twitter:image" content="./icons/icon-512.png" />
+
+
     <link rel="icon" href="./favicon.ico" sizes="any" />
     <link rel="icon" href="./icons/icon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -4714,9 +4714,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "vite-plugin-pwa": {
       "vite": "$vite"
     },
-    "brace-expansion": "^5.0.5",
-    "lodash": "^4.18.0",
-    "three": "^0.125.0"
+    "brace-expansion": "~5.0.9",
+    "lodash": "~4.18.1",
+    "three": "~0.125.2"
   }
 }

--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import pngToIco from "png-to-ico";
@@ -33,3 +33,24 @@ for (const size of faviconSizes) {
 const icoBuffer: Buffer = await pngToIco(faviconPngs);
 const faviconDest: string = resolve(root, "public", "favicon.ico");
 writeFileSync(faviconDest, icoBuffer);
+
+/** Branded placeholder screenshots for the Web App Manifest `screenshots` member. */
+async function writeScreenshot(width: number, height: number, file: string): Promise<void> {
+  const iconSize = Math.round(Math.min(width, height) * 0.4);
+  const icon = await sharp(svg, { density }).resize(iconSize, iconSize).png().toBuffer();
+  await sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: THEME_BG,
+    },
+  })
+    .composite([{ input: icon, gravity: "center" }])
+    .png()
+    .toFile(resolve(publicDir, file));
+}
+
+mkdirSync(resolve(publicDir, "screenshots"), { recursive: true });
+await writeScreenshot(1280, 720, "screenshots/wide.png");
+await writeScreenshot(720, 1280, "screenshots/narrow.png");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { VitePWA } from "vite-plugin-pwa";
  * Security headers required for:
  *  - COOP/COEP: SharedArrayBuffer support
  *  - CSP: restrict resource loading to same-origin + known blob/data exceptions
+ *  - Referrer / Permissions: tighten default browser leakage
  *  - X-Content-Type-Options: prevent MIME sniffing
  *  - X-Frame-Options: prevent clickjacking (belt-and-suspenders alongside frame-ancestors)
  */
@@ -14,9 +15,17 @@ const securityHeaders: Record<string, string> = {
   "Cross-Origin-Embedder-Policy": "require-corp",
   "Content-Security-Policy": [
     "default-src 'self'",
+    // TODO(scenerystack): drop 'unsafe-eval' when SceneryStack no longer needs
+
+    // Function/eval for query-parameter parsing — reopen a CSP audit then.
+
     // 'unsafe-eval' is required for SceneryStack query parameter parsing
     "script-src 'self' 'unsafe-eval'",
     "worker-src blob: 'self'",
+    // TODO(scenerystack): drop 'unsafe-inline' when SceneryStack stops setting
+
+    // element.style / cssText for theming (same CSP revisit as unsafe-eval).
+
     // Inline styles are set via element.style / cssText throughout the UI layer
     "style-src 'self' 'unsafe-inline'",
     // data: for icons
@@ -29,9 +38,17 @@ const securityHeaders: Record<string, string> = {
     "base-uri 'self'",
     "frame-ancestors 'none'",
   ].join("; "),
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
   "X-Content-Type-Options": "nosniff",
   "X-Frame-Options": "DENY",
 };
+
+/** Single-file mode: inline every imported asset as base64 (effectively unlimited). */
+const INLINE_LIMIT_BYTES = 100 * 1024 * 1024;
+
+/** Workbox precache ceiling — SceneryStack bundles exceed the default 2 MB limit. */
+const WORKBOX_MAX_FILE_BYTES = 12 * 1024 * 1024;
 
 /** Escape a string for literal use inside a `RegExp`. */
 function escapeRegExp(value: string): string {
@@ -130,7 +147,7 @@ export default defineConfig(({ mode }) => {
       chunkSizeWarningLimit: 5000,
       ...(single && {
         // Inline every imported asset as a base64 data URI instead of emitting files.
-        assetsInlineLimit: 100_000_000,
+        assetsInlineLimit: INLINE_LIMIT_BYTES,
         // Emit one CSS file (no per-chunk split) so there is a single tag to inline.
         cssCodeSplit: false,
         // Skip copying public/ (favicon, icons) — nothing external should remain.
@@ -154,17 +171,21 @@ export default defineConfig(({ mode }) => {
             registerType: "autoUpdate",
             includeAssets: ["favicon.ico", "icons/apple-touch-icon.png"],
             manifest: {
+              id: "optics-lab",
               name: "Optics Lab",
               // biome-ignore lint/style/useNamingConvention: Web App Manifest spec requires snake_case keys
               short_name: "OpticsLab",
               description:
                 "Web-based geometric optics simulation with ray sources, mirrors, lenses, beam splitters, and refraction interfaces.",
+              categories: ["education", "science"],
               // biome-ignore lint/style/useNamingConvention: Web App Manifest spec requires snake_case keys
               theme_color: "#1a1a2e",
               // biome-ignore lint/style/useNamingConvention: Web App Manifest spec requires snake_case keys
               background_color: "#000000",
               display: "standalone",
-              orientation: "landscape",
+              // biome-ignore lint/style/useNamingConvention: Web App Manifest spec requires snake_case keys
+              display_override: ["window-controls-overlay", "standalone"],
+              // No `orientation` — leave free so portrait-friendly sims are not forced landscape.
               icons: [
                 {
                   src: "icons/icon-192.png",
@@ -183,9 +204,28 @@ export default defineConfig(({ mode }) => {
                   purpose: "maskable",
                 },
               ],
+              // Placeholder shots from `npm run icons`; replace with real sim screenshots before shipping.
+              screenshots: [
+                {
+                  src: "screenshots/wide.png",
+                  sizes: "1280x720",
+                  type: "image/png",
+                  // biome-ignore lint/style/useNamingConvention: Web App Manifest spec requires snake_case keys
+                  form_factor: "wide",
+                  label: "OpticsLab",
+                },
+                {
+                  src: "screenshots/narrow.png",
+                  sizes: "720x1280",
+                  type: "image/png",
+                  // biome-ignore lint/style/useNamingConvention: Web App Manifest spec requires snake_case keys
+                  form_factor: "narrow",
+                  label: "OpticsLab",
+                },
+              ],
             },
             workbox: {
-              maximumFileSizeToCacheInBytes: 12 * 1024 * 1024,
+              maximumFileSizeToCacheInBytes: WORKBOX_MAX_FILE_BYTES,
               globPatterns: ["**/*.{js,css,html,svg,png,woff2}"],
             },
           }),


### PR DESCRIPTION
## Summary
Ports portable pieces of [SceneryStackTemplate@ab309a1](https://github.com/OpenPhysics/SceneryStackTemplate/commit/ab309a1c0c2c7df464cb926a85852812229296c1) across the fleet:

- Dependabot ignore for forced `lodash` / `three` / `brace-expansion` overrides
- Tilde override pins (`~4.18.1`, `~0.125.2`, `~5.0.9`); preserves sim-specific extras; LightPropagation keeps its higher `three` pin
- `Referrer-Policy` + `Permissions-Policy` + CSP TODOs; named Vite size constants
- PWA `id` / `categories` / `display_override` / placeholder `screenshots`; drop forced `orientation: landscape`
- `index.html` description + Open Graph / Twitter meta; README CI badge
- CLAUDE.md package.json overrides table

Skipped (template-only / sim-specific): rename-sim, StringManager return types, KeyboardHelp/ScreenView dispose stubs.

## Test plan
- [ ] CI green on this PR
- [ ] Spot-check install prompt / meta tags after deploy