### PR TITLE
fix: restore generate-icons locals after template hardening

### DIFF
--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -9,6 +9,12 @@ const root: string = resolve(scriptDir, "..");
 
 const svgBuffer: Buffer = readFileSync(resolve(root, "public/icons/icon.svg"));
 
+/** Theme background matching `theme_color` / icon.svg fill (`#1a1a2e`). */
+const THEME_BG = { r: 0x1a, g: 0x1a, b: 0x2e, alpha: 1 };
+
+const density = 512;
+const publicDir = resolve(root, "public");
+
 const pngIcons: Array<{ name: string; size: number }> = [
   { name: "icons/apple-touch-icon.png", size: 180 },
   { name: "icons/icon-192.png", size: 192 },
@@ -37,7 +43,7 @@ writeFileSync(faviconDest, icoBuffer);
 /** Branded placeholder screenshots for the Web App Manifest `screenshots` member. */
 async function writeScreenshot(width: number, height: number, file: string): Promise<void> {
   const iconSize = Math.round(Math.min(width, height) * 0.4);
-  const icon = await sharp(svg, { density }).resize(iconSize, iconSize).png().toBuffer();
+  const icon = await sharp(svgBuffer, { density }).resize(iconSize, iconSize).png().toBuffer();
   await sharp({
     create: {
       width,


### PR DESCRIPTION
## Summary
- Template-hardening appended a screenshot helper that referenced `svg` / `density` / `publicDir` / `THEME_BG`, which this sim does not declare.
- Biome `noUndeclaredVariables` failed `ci / build` on the merged hardening PR (#88).
- Wire the helper to the existing `svgBuffer` / `root` locals and declare the missing constants.

## Test plan
- [x] `npm run lint && npm run check && npm run build`
- [x] `npm test` (416 passed)


Made with [Cursor](https://cursor.com)