### PR TITLE
ci: allow manual Pages deploys and sync Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
-      # Forced in package.json overrides (see CLAUDE.md → package.json overrides).
+      # Forced in package.json overrides (see each repo's CLAUDE.md → package.json overrides).
       # Dependabot PRs would fight the pin / reopen known-accepted risk.
       - dependency-name: "lodash"
       - dependency-name: "three"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,10 @@ name: Deploy
 on:
   push:
     branches: [main]
+  # Manual dispatch, so the site can be published without waiting for a push and
+  # so a deploy that never fired can be recovered by hand. Matches Baton's own
+  # pages.yml, which carries the same pair of triggers.
+  workflow_dispatch:
 
 concurrency:
   group: pages-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to `.github/workflows/deploy.yml` so Pages can be published without a push (same triggers as Baton's `pages.yml` / CrystalLattice).
- Sync `.github/dependabot.yml` from `Baton/config/dependabot-npm.yml` (comment-only drift).

## Test plan
- [ ] Confirm the Deploy workflow lists **Run workflow** on the Actions tab
- [ ] Confirm Dependabot config still ignores `@types/node` majors plus `lodash` / `three` / `brace-expansion`

Made with [Cursor](https://cursor.com)